### PR TITLE
chore: remove all is_dummy fields

### DIFF
--- a/app/Jobs/AttachEmployeeToShip.php
+++ b/app/Jobs/AttachEmployeeToShip.php
@@ -31,17 +31,11 @@ class AttachEmployeeToShip implements ShouldQueue
      */
     public function handle()
     {
-        $isDummy = true;
-        if (empty($this->data['is_dummy'])) {
-            $isDummy = false;
-        }
-
         (new ShipAttachEmployeeToShip)->execute([
             'company_id' => $this->data['company_id'],
             'author_id' => $this->data['author_id'],
             'employee_id' => $this->data['employee_id'],
             'ship_id' => $this->data['ship_id'],
-            'is_dummy' => $isDummy,
         ]);
     }
 }

--- a/app/Jobs/LogAccountAudit.php
+++ b/app/Jobs/LogAccountAudit.php
@@ -33,11 +33,6 @@ class LogAccountAudit implements ShouldQueue
      */
     public function handle()
     {
-        $isDummy = true;
-        if (empty($this->auditLog['is_dummy'])) {
-            $isDummy = false;
-        }
-
         (new LogAccountAction)->execute([
             'company_id' => $this->auditLog['company_id'],
             'author_id' => $this->auditLog['author_id'],
@@ -45,7 +40,6 @@ class LogAccountAudit implements ShouldQueue
             'audited_at' => $this->auditLog['audited_at'],
             'action' => $this->auditLog['action'],
             'objects' => $this->auditLog['objects'],
-            'is_dummy' => $isDummy,
         ]);
     }
 }

--- a/app/Jobs/LogEmployeeAudit.php
+++ b/app/Jobs/LogEmployeeAudit.php
@@ -33,11 +33,6 @@ class LogEmployeeAudit implements ShouldQueue
      */
     public function handle()
     {
-        $isDummy = true;
-        if (empty($this->auditLog['is_dummy'])) {
-            $isDummy = false;
-        }
-
         (new LogEmployeeAction)->execute([
             'employee_id' => $this->auditLog['employee_id'],
             'author_id' => $this->auditLog['author_id'],
@@ -45,7 +40,6 @@ class LogEmployeeAudit implements ShouldQueue
             'audited_at' => $this->auditLog['audited_at'],
             'action' => $this->auditLog['action'],
             'objects' => $this->auditLog['objects'],
-            'is_dummy' => $isDummy,
         ]);
     }
 }

--- a/app/Jobs/LogTeamAudit.php
+++ b/app/Jobs/LogTeamAudit.php
@@ -33,11 +33,6 @@ class LogTeamAudit implements ShouldQueue
      */
     public function handle()
     {
-        $isDummy = true;
-        if (empty($this->auditLog['is_dummy'])) {
-            $isDummy = false;
-        }
-
         (new LogTeamAction)->execute([
             'team_id' => $this->auditLog['team_id'],
             'author_id' => $this->auditLog['author_id'],
@@ -45,7 +40,6 @@ class LogTeamAudit implements ShouldQueue
             'audited_at' => $this->auditLog['audited_at'],
             'action' => $this->auditLog['action'],
             'objects' => $this->auditLog['objects'],
-            'is_dummy' => $isDummy,
         ]);
     }
 }

--- a/app/Jobs/NotifyEmployee.php
+++ b/app/Jobs/NotifyEmployee.php
@@ -33,16 +33,10 @@ class NotifyEmployee implements ShouldQueue
      */
     public function handle()
     {
-        $isDummy = true;
-        if (empty($this->notification['is_dummy'])) {
-            $isDummy = false;
-        }
-
         (new AddNotificationInUIForEmployee)->execute([
             'employee_id' => $this->notification['employee_id'],
             'action' => $this->notification['action'],
             'objects' => $this->notification['objects'],
-            'is_dummy' => $isDummy,
         ]);
     }
 }

--- a/app/Models/Company/AuditLog.php
+++ b/app/Models/Company/AuditLog.php
@@ -24,16 +24,6 @@ class AuditLog extends Model
         'objects',
         'audited_at',
         'ip_address',
-        'is_dummy',
-    ];
-
-    /**
-     * The attributes that should be cast to native types.
-     *
-     * @var array
-     */
-    protected $casts = [
-        'is_dummy' => 'boolean',
     ];
 
     /**

--- a/app/Models/Company/CompanyCalendar.php
+++ b/app/Models/Company/CompanyCalendar.php
@@ -24,7 +24,6 @@ class CompanyCalendar extends Model
         'day_of_week',
         'day_of_year',
         'is_worked',
-        'is_dummy',
     ];
 
     /**
@@ -34,7 +33,6 @@ class CompanyCalendar extends Model
      */
     protected $casts = [
         'is_worked' => 'boolean',
-        'is_dummy' => 'boolean',
     ];
 
     /**

--- a/app/Models/Company/CompanyNews.php
+++ b/app/Models/Company/CompanyNews.php
@@ -25,7 +25,6 @@ class CompanyNews extends Model
         'author_name',
         'title',
         'content',
-        'is_dummy',
         'created_at',
     ];
 

--- a/app/Models/Company/CompanyPTOPolicy.php
+++ b/app/Models/Company/CompanyPTOPolicy.php
@@ -26,7 +26,6 @@ class CompanyPTOPolicy extends Model
         'default_amount_of_allowed_holidays',
         'default_amount_of_sick_days',
         'default_amount_of_pto_days',
-        'is_dummy',
         'created_at',
     ];
 

--- a/app/Models/Company/Employee.php
+++ b/app/Models/Company/Employee.php
@@ -54,7 +54,6 @@ class Employee extends Model
         'default_dashboard_view',
         'can_manage_expenses',
         'display_welcome_message',
-        'is_dummy',
     ];
 
     /**
@@ -103,7 +102,6 @@ class Employee extends Model
         'locked' => 'boolean',
         'can_manage_expenses' => 'boolean',
         'display_welcome_message' => 'boolean',
-        'is_dummy' => 'boolean',
     ];
 
     /**

--- a/app/Models/Company/EmployeeDailyCalendarEntry.php
+++ b/app/Models/Company/EmployeeDailyCalendarEntry.php
@@ -31,7 +31,6 @@ class EmployeeDailyCalendarEntry extends Model
         'daily_accrued_amount',
         'current_holidays_per_year',
         'default_amount_of_allowed_holidays_in_company',
-        'is_dummy',
     ];
 
     /**

--- a/app/Models/Company/EmployeeLog.php
+++ b/app/Models/Company/EmployeeLog.php
@@ -27,16 +27,6 @@ class EmployeeLog extends Model
         'objects',
         'audited_at',
         'ip_address',
-        'is_dummy',
-    ];
-
-    /**
-     * The attributes that should be cast to native types.
-     *
-     * @var array
-     */
-    protected $casts = [
-        'is_dummy' => 'boolean',
     ];
 
     /**

--- a/app/Models/Company/EmployeePlannedHoliday.php
+++ b/app/Models/Company/EmployeePlannedHoliday.php
@@ -20,7 +20,6 @@ class EmployeePlannedHoliday extends Model
         'type',
         'full',
         'actually_taken',
-        'is_dummy',
     ];
 
     /**
@@ -40,7 +39,6 @@ class EmployeePlannedHoliday extends Model
     protected $casts = [
         'full' => 'boolean',
         'actually_taken' => 'boolean',
-        'is_dummy' => 'boolean',
     ];
 
     /**

--- a/app/Models/Company/EmployeeStatus.php
+++ b/app/Models/Company/EmployeeStatus.php
@@ -20,7 +20,6 @@ class EmployeeStatus extends Model
     protected $fillable = [
         'company_id',
         'name',
-        'is_dummy',
     ];
 
     /**

--- a/app/Models/Company/Flow.php
+++ b/app/Models/Company/Flow.php
@@ -20,7 +20,6 @@ class Flow extends Model
         'company_id',
         'name',
         'type',
-        'is_dummy',
     ];
 
     /**
@@ -30,15 +29,6 @@ class Flow extends Model
      */
     protected static $logAttributes = [
         'name',
-    ];
-
-    /**
-     * The attributes that should be cast to native types.
-     *
-     * @var array
-     */
-    protected $casts = [
-        'is_dummy' => 'boolean',
     ];
 
     /**

--- a/app/Models/Company/Hardware.php
+++ b/app/Models/Company/Hardware.php
@@ -28,7 +28,6 @@ class Hardware extends Model
         'company_id',
         'name',
         'serial_number',
-        'is_dummy',
     ];
 
     /**
@@ -59,15 +58,6 @@ class Hardware extends Model
      */
     protected static $logAttributes = [
         'name',
-    ];
-
-    /**
-     * The attributes that should be cast to native types.
-     *
-     * @var array
-     */
-    protected $casts = [
-        'is_dummy' => 'boolean',
     ];
 
     /**

--- a/app/Models/Company/Morale.php
+++ b/app/Models/Company/Morale.php
@@ -21,7 +21,6 @@ class Morale extends Model
         'employee_id',
         'emotion',
         'comment',
-        'is_dummy',
         'created_at',
     ];
 
@@ -33,15 +32,6 @@ class Morale extends Model
     protected static $logAttributes = [
         'emotion',
         'comment',
-    ];
-
-    /**
-     * The attributes that should be cast to native types.
-     *
-     * @var array
-     */
-    protected $casts = [
-        'is_dummy' => 'boolean',
     ];
 
     /**

--- a/app/Models/Company/MoraleCompanyHistory.php
+++ b/app/Models/Company/MoraleCompanyHistory.php
@@ -18,16 +18,6 @@ class MoraleCompanyHistory extends Model
         'company_id',
         'average',
         'number_of_employees',
-        'is_dummy',
-    ];
-
-    /**
-     * The attributes that should be cast to native types.
-     *
-     * @var array
-     */
-    protected $casts = [
-        'is_dummy' => 'boolean',
     ];
 
     /**

--- a/app/Models/Company/MoraleTeamHistory.php
+++ b/app/Models/Company/MoraleTeamHistory.php
@@ -18,16 +18,6 @@ class MoraleTeamHistory extends Model
         'team_id',
         'average',
         'number_of_team_members',
-        'is_dummy',
-    ];
-
-    /**
-     * The attributes that should be cast to native types.
-     *
-     * @var array
-     */
-    protected $casts = [
-        'is_dummy' => 'boolean',
     ];
 
     /**

--- a/app/Models/Company/Notification.php
+++ b/app/Models/Company/Notification.php
@@ -18,7 +18,6 @@ class Notification extends Model
         'action',
         'objects',
         'read',
-        'is_dummy',
     ];
 
     /**
@@ -28,7 +27,6 @@ class Notification extends Model
      */
     protected $casts = [
         'read' => 'boolean',
-        'is_dummy' => 'boolean',
     ];
 
     /**

--- a/app/Models/Company/Place.php
+++ b/app/Models/Company/Place.php
@@ -23,7 +23,6 @@ class Place extends Model
         'placable_id',
         'placable_type',
         'is_active',
-        'is_dummy',
     ];
 
     /**
@@ -33,7 +32,6 @@ class Place extends Model
      */
     protected $casts = [
         'is_active' => 'boolean',
-        'is_dummy' => 'boolean',
     ];
 
     /**

--- a/app/Models/Company/Position.php
+++ b/app/Models/Company/Position.php
@@ -21,7 +21,6 @@ class Position extends Model
     protected $fillable = [
         'company_id',
         'title',
-        'is_dummy',
     ];
 
     /**
@@ -50,15 +49,6 @@ class Position extends Model
      */
     protected static $logAttributes = [
         'title',
-    ];
-
-    /**
-     * The attributes that should be cast to native types.
-     *
-     * @var array
-     */
-    protected $casts = [
-        'is_dummy' => 'boolean',
     ];
 
     /**

--- a/app/Models/Company/Question.php
+++ b/app/Models/Company/Question.php
@@ -23,7 +23,6 @@ class Question extends Model
         'activated_at',
         'deactivated_at',
         'active',
-        'is_dummy',
     ];
 
     /**
@@ -52,7 +51,6 @@ class Question extends Model
      */
     protected $casts = [
         'active' => 'boolean',
-        'is_dummy' => 'boolean',
     ];
 
     /**

--- a/app/Models/Company/Ship.php
+++ b/app/Models/Company/Ship.php
@@ -20,7 +20,6 @@ class Ship extends Model
         'team_id',
         'title',
         'description',
-        'is_dummy',
     ];
 
     /**
@@ -31,15 +30,6 @@ class Ship extends Model
     protected static $logAttributes = [
         'title',
         'description',
-    ];
-
-    /**
-     * The attributes that should be cast to native types.
-     *
-     * @var array
-     */
-    protected $casts = [
-        'is_dummy' => 'boolean',
     ];
 
     /**

--- a/app/Models/Company/Skill.php
+++ b/app/Models/Company/Skill.php
@@ -21,7 +21,6 @@ class Skill extends Model
     protected $fillable = [
         'company_id',
         'name',
-        'is_dummy',
     ];
 
     /**
@@ -50,15 +49,6 @@ class Skill extends Model
      */
     protected static $logAttributes = [
         'name',
-    ];
-
-    /**
-     * The attributes that should be cast to native types.
-     *
-     * @var array
-     */
-    protected $casts = [
-        'is_dummy' => 'boolean',
     ];
 
     /**

--- a/app/Models/Company/Task.php
+++ b/app/Models/Company/Task.php
@@ -25,7 +25,6 @@ class Task extends Model
         'completed',
         'due_at',
         'completed_at',
-        'is_dummy',
     ];
 
     /**
@@ -45,7 +44,6 @@ class Task extends Model
      */
     protected $casts = [
         'completed' => 'boolean',
-        'is_dummy' => 'boolean',
     ];
 
     /**

--- a/app/Models/Company/Team.php
+++ b/app/Models/Company/Team.php
@@ -26,7 +26,6 @@ class Team extends Model
         'name',
         'description',
         'team_leader_id',
-        'is_dummy',
     ];
 
     /**
@@ -56,15 +55,6 @@ class Team extends Model
      */
     protected static $logAttributes = [
         'name',
-    ];
-
-    /**
-     * The attributes that should be cast to native types.
-     *
-     * @var array
-     */
-    protected $casts = [
-        'is_dummy' => 'boolean',
     ];
 
     /**

--- a/app/Models/Company/TeamLog.php
+++ b/app/Models/Company/TeamLog.php
@@ -24,16 +24,6 @@ class TeamLog extends Model
         'author_name',
         'audited_at',
         'ip_address',
-        'is_dummy',
-    ];
-
-    /**
-     * The attributes that should be cast to native types.
-     *
-     * @var array
-     */
-    protected $casts = [
-        'is_dummy' => 'boolean',
     ];
 
     /**

--- a/app/Models/Company/TeamNews.php
+++ b/app/Models/Company/TeamNews.php
@@ -25,7 +25,6 @@ class TeamNews extends Model
         'author_name',
         'title',
         'content',
-        'is_dummy',
         'created_at',
     ];
 

--- a/app/Models/Company/TeamUsefulLink.php
+++ b/app/Models/Company/TeamUsefulLink.php
@@ -22,15 +22,6 @@ class TeamUsefulLink extends Model
     ];
 
     /**
-     * The attributes that should be cast to native types.
-     *
-     * @var array
-     */
-    protected $casts = [
-        'is_dummy' => 'boolean',
-    ];
-
-    /**
      * Get the team record associated with the team useful link object.
      *
      * @return BelongsTo

--- a/app/Models/Company/Worklog.php
+++ b/app/Models/Company/Worklog.php
@@ -22,7 +22,6 @@ class Worklog extends Model
     protected $fillable = [
         'employee_id',
         'content',
-        'is_dummy',
         'created_at',
     ];
 
@@ -33,15 +32,6 @@ class Worklog extends Model
      */
     protected static $logAttributes = [
         'content',
-    ];
-
-    /**
-     * The attributes that should be cast to native types.
-     *
-     * @var array
-     */
-    protected $casts = [
-        'is_dummy' => 'boolean',
     ];
 
     /**

--- a/app/Services/Company/Adminland/Company/AddUserToCompany.php
+++ b/app/Services/Company/Adminland/Company/AddUserToCompany.php
@@ -23,7 +23,6 @@ class AddUserToCompany extends BaseService
             'author_id' => 'required|integer|exists:employees,id',
             'user_id' => 'required|integer|exists:users,id',
             'permission_level' => 'required|integer',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -60,7 +59,6 @@ class AddUserToCompany extends BaseService
                 'user_id' => $employee->user->id,
                 'user_email' => $employee->user->email,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         return $employee;

--- a/app/Services/Company/Adminland/CompanyNews/CreateCompanyNews.php
+++ b/app/Services/Company/Adminland/CompanyNews/CreateCompanyNews.php
@@ -22,7 +22,6 @@ class CreateCompanyNews extends BaseService
             'title' => 'required|string|max:255',
             'content' => 'required|string|max:65535',
             'created_at' => 'nullable|date_format:Y-m-d H:i:s',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -48,7 +47,6 @@ class CreateCompanyNews extends BaseService
             'author_name' => $this->author->name,
             'title' => $data['title'],
             'content' => $data['content'],
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ]);
 
         if (! empty($data['created_at'])) {
@@ -66,7 +64,6 @@ class CreateCompanyNews extends BaseService
                 'company_news_id' => $news->id,
                 'company_news_title' => $news->title,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         return $news;

--- a/app/Services/Company/Adminland/CompanyNews/DestroyCompanyNews.php
+++ b/app/Services/Company/Adminland/CompanyNews/DestroyCompanyNews.php
@@ -20,7 +20,6 @@ class DestroyCompanyNews extends BaseService
             'company_id' => 'required|integer|exists:companies,id',
             'author_id' => 'required|integer|exists:employees,id',
             'company_news_id' => 'required|integer|exists:company_news,id',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -54,7 +53,6 @@ class DestroyCompanyNews extends BaseService
             'objects' => json_encode([
                 'company_news_title' => $news->title,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         return true;

--- a/app/Services/Company/Adminland/CompanyNews/UpdateCompanyNews.php
+++ b/app/Services/Company/Adminland/CompanyNews/UpdateCompanyNews.php
@@ -23,7 +23,6 @@ class UpdateCompanyNews extends BaseService
             'company_news_id' => 'required|integer|exists:company_news,id',
             'title' => 'required|string|max:255',
             'content' => 'required|string|max:65535',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -63,7 +62,6 @@ class UpdateCompanyNews extends BaseService
                 'company_news_title' => $news->title,
                 'company_news_old_title' => $oldNewsTitle,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         $news->refresh();

--- a/app/Services/Company/Adminland/CompanyPTOPolicy/CreateCompanyPTOPolicy.php
+++ b/app/Services/Company/Adminland/CompanyPTOPolicy/CreateCompanyPTOPolicy.php
@@ -26,7 +26,6 @@ class CreateCompanyPTOPolicy extends BaseService
             'default_amount_of_allowed_holidays' => 'required|integer',
             'default_amount_of_sick_days' => 'required|integer',
             'default_amount_of_pto_days' => 'required|integer',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -63,7 +62,6 @@ class CreateCompanyPTOPolicy extends BaseService
             'default_amount_of_allowed_holidays' => $data['default_amount_of_allowed_holidays'],
             'default_amount_of_sick_days' => $data['default_amount_of_sick_days'],
             'default_amount_of_pto_days' => $data['default_amount_of_pto_days'],
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ]);
 
         // fix the number of worked days to be sure
@@ -82,7 +80,6 @@ class CreateCompanyPTOPolicy extends BaseService
                 'company_pto_policy_id' => $ptoPolicy->id,
                 'company_pto_policy_year' => $ptoPolicy->year,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         return $ptoPolicy;

--- a/app/Services/Company/Adminland/CompanyPTOPolicy/UpdateCompanyPTOPolicy.php
+++ b/app/Services/Company/Adminland/CompanyPTOPolicy/UpdateCompanyPTOPolicy.php
@@ -27,7 +27,6 @@ class UpdateCompanyPTOPolicy extends BaseService
             'default_amount_of_allowed_holidays' => 'nullable|integer',
             'default_amount_of_sick_days' => 'nullable|integer',
             'default_amount_of_pto_days' => 'nullable|integer',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -68,7 +67,6 @@ class UpdateCompanyPTOPolicy extends BaseService
                 'company_pto_policy_id' => $ptoPolicy->id,
                 'company_pto_policy_year' => $ptoPolicy->year,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         $ptoPolicy->refresh();

--- a/app/Services/Company/Adminland/Employee/AddEmployeeToCompany.php
+++ b/app/Services/Company/Adminland/Employee/AddEmployeeToCompany.php
@@ -31,7 +31,6 @@ class AddEmployeeToCompany extends BaseService
             'last_name' => 'required|string|max:255',
             'permission_level' => 'required|integer',
             'send_invitation' => 'required|boolean',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -94,7 +93,6 @@ class AddEmployeeToCompany extends BaseService
             'last_name' => $data['last_name'],
             'avatar' => $avatar,
             'permission_level' => $data['permission_level'],
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ]);
 
         LogEmployeeAudit::dispatch([
@@ -107,7 +105,6 @@ class AddEmployeeToCompany extends BaseService
                 'employee_id' => $this->employee->id,
                 'employee_name' => $this->employee->name,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         return $this->employee;
@@ -164,7 +161,6 @@ class AddEmployeeToCompany extends BaseService
                 'employee_last_name' => $data['last_name'],
                 'employee_name' => $this->employee->name,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
     }
 }

--- a/app/Services/Company/Adminland/Employee/DestroyEmployee.php
+++ b/app/Services/Company/Adminland/Employee/DestroyEmployee.php
@@ -21,7 +21,6 @@ class DestroyEmployee extends BaseService
             'author_id' => 'required|integer|exists:employees,id',
             'employee_id' => 'required|exists:employees,id|integer',
             'company_id' => 'required|exists:companies,id|integer',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -55,7 +54,6 @@ class DestroyEmployee extends BaseService
             'objects' => json_encode([
                 'employee_name' => $employee->name,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
     }
 }

--- a/app/Services/Company/Adminland/Employee/InviteEmployeeToBecomeUser.php
+++ b/app/Services/Company/Adminland/Employee/InviteEmployeeToBecomeUser.php
@@ -29,7 +29,6 @@ class InviteEmployeeToBecomeUser extends BaseService
             'company_id' => 'required|integer|exists:companies,id',
             'author_id' => 'required|integer|exists:employees,id',
             'employee_id' => 'required|integer|exists:employees,id',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -65,7 +64,6 @@ class InviteEmployeeToBecomeUser extends BaseService
                 'employee_first_name' => $employee->first_name,
                 'employee_last_name' => $employee->last_name,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         return $employee;

--- a/app/Services/Company/Adminland/Employee/LockEmployee.php
+++ b/app/Services/Company/Adminland/Employee/LockEmployee.php
@@ -26,7 +26,6 @@ class LockEmployee extends BaseService
             'author_id' => 'required|integer|exists:employees,id',
             'employee_id' => 'required|exists:employees,id|integer',
             'company_id' => 'required|exists:companies,id|integer',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -64,7 +63,6 @@ class LockEmployee extends BaseService
             'objects' => json_encode([
                 'employee_name' => $this->employee->name,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         LogEmployeeAudit::dispatch([
@@ -74,7 +72,6 @@ class LockEmployee extends BaseService
             'author_name' => $this->author->name,
             'audited_at' => Carbon::now(),
             'objects' => json_encode([]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
     }
 

--- a/app/Services/Company/Adminland/Employee/UnlockEmployee.php
+++ b/app/Services/Company/Adminland/Employee/UnlockEmployee.php
@@ -21,7 +21,6 @@ class UnlockEmployee extends BaseService
             'author_id' => 'required|integer|exists:employees,id',
             'employee_id' => 'required|exists:employees,id|integer',
             'company_id' => 'required|exists:companies,id|integer',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -53,7 +52,6 @@ class UnlockEmployee extends BaseService
             'objects' => json_encode([
                 'employee_name' => $employee->name,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         LogEmployeeAudit::dispatch([
@@ -63,7 +61,6 @@ class UnlockEmployee extends BaseService
             'author_name' => $this->author->name,
             'audited_at' => Carbon::now(),
             'objects' => json_encode([]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
     }
 }

--- a/app/Services/Company/Adminland/Employee/UpdateEmployee.php
+++ b/app/Services/Company/Adminland/Employee/UpdateEmployee.php
@@ -23,7 +23,6 @@ class UpdateEmployee extends BaseService
             'email' => 'required|email|max:255',
             'first_name' => 'required|string|max:255',
             'last_name' => 'required|string|max:255',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -63,7 +62,6 @@ class UpdateEmployee extends BaseService
                 'employee_id' => $employee->id,
                 'employee_name' => $employee->name,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         return $employee;

--- a/app/Services/Company/Adminland/EmployeeStatus/CreateEmployeeStatus.php
+++ b/app/Services/Company/Adminland/EmployeeStatus/CreateEmployeeStatus.php
@@ -20,7 +20,6 @@ class CreateEmployeeStatus extends BaseService
             'company_id' => 'required|integer|exists:companies,id',
             'author_id' => 'required|integer|exists:employees,id',
             'name' => 'required|string|max:255',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -55,7 +54,6 @@ class CreateEmployeeStatus extends BaseService
                 'employee_status_id' => $employeeStatus->id,
                 'employee_status_name' => $employeeStatus->name,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         return $employeeStatus;

--- a/app/Services/Company/Adminland/EmployeeStatus/DestroyEmployeeStatus.php
+++ b/app/Services/Company/Adminland/EmployeeStatus/DestroyEmployeeStatus.php
@@ -20,7 +20,6 @@ class DestroyEmployeeStatus extends BaseService
             'company_id' => 'required|integer|exists:companies,id',
             'author_id' => 'required|integer|exists:employees,id',
             'employee_status_id' => 'required|integer|exists:employee_statuses,id',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -54,7 +53,6 @@ class DestroyEmployeeStatus extends BaseService
             'objects' => json_encode([
                 'employee_status_name' => $employeeStatus->name,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         return true;

--- a/app/Services/Company/Adminland/EmployeeStatus/UpdateEmployeeStatus.php
+++ b/app/Services/Company/Adminland/EmployeeStatus/UpdateEmployeeStatus.php
@@ -21,7 +21,6 @@ class UpdateEmployeeStatus extends BaseService
             'author_id' => 'required|integer|exists:employees,id',
             'employee_status_id' => 'required|integer|exists:employee_statuses,id',
             'name' => 'required|string|max:255',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -61,7 +60,6 @@ class UpdateEmployeeStatus extends BaseService
                 'employee_status_old_name' => $oldStatusName,
                 'employee_status_new_name' => $data['name'],
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         return $employeeStatus;

--- a/app/Services/Company/Adminland/Expense/AllowEmployeeToManageExpenses.php
+++ b/app/Services/Company/Adminland/Expense/AllowEmployeeToManageExpenses.php
@@ -80,7 +80,6 @@ class AllowEmployeeToManageExpenses extends BaseService
             'author_name' => $this->author->name,
             'audited_at' => Carbon::now(),
             'objects' => json_encode([]),
-            'is_dummy' => $this->valueOrFalse($this->data, 'is_dummy'),
         ])->onQueue('low');
 
         NotifyEmployee::dispatch([

--- a/app/Services/Company/Adminland/Expense/DisallowEmployeeToManageExpenses.php
+++ b/app/Services/Company/Adminland/Expense/DisallowEmployeeToManageExpenses.php
@@ -79,7 +79,6 @@ class DisallowEmployeeToManageExpenses extends BaseService
             'author_name' => $this->author->name,
             'audited_at' => Carbon::now(),
             'objects' => json_encode([]),
-            'is_dummy' => $this->valueOrFalse($this->data, 'is_dummy'),
         ])->onQueue('low');
     }
 }

--- a/app/Services/Company/Adminland/Flow/CreateFlow.php
+++ b/app/Services/Company/Adminland/Flow/CreateFlow.php
@@ -36,7 +36,6 @@ class CreateFlow extends BaseService
                     'employee_returns_leave',
                 ]),
             ],
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -72,7 +71,6 @@ class CreateFlow extends BaseService
                 'flow_id' => $flow->id,
                 'flow_name' => $flow->name,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         return $flow;

--- a/app/Services/Company/Adminland/Flow/RemoveActionFromStep.php
+++ b/app/Services/Company/Adminland/Flow/RemoveActionFromStep.php
@@ -21,7 +21,6 @@ class RemoveActionFromStep extends BaseService
             'author_id' => 'required|integer|exists:employees,id',
             'step_id' => 'required|integer|exists:steps,id',
             'action_id' => 'required|integer|exists:actions,id',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 

--- a/app/Services/Company/Adminland/Flow/RemoveStepFromFlow.php
+++ b/app/Services/Company/Adminland/Flow/RemoveStepFromFlow.php
@@ -20,7 +20,6 @@ class RemoveStepFromFlow extends BaseService
             'author_id' => 'required|integer|exists:employees,id',
             'flow_id' => 'required|integer|exists:flows,id',
             'step_id' => 'required|integer|exists:steps,id',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 

--- a/app/Services/Company/Adminland/Hardware/CreateHardware.php
+++ b/app/Services/Company/Adminland/Hardware/CreateHardware.php
@@ -21,7 +21,6 @@ class CreateHardware extends BaseService
             'author_id' => 'required|integer|exists:employees,id',
             'name' => 'required|string|max:255',
             'serial_number' => 'nullable|string|max:255',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -45,7 +44,6 @@ class CreateHardware extends BaseService
             'company_id' => $data['company_id'],
             'name' => $data['name'],
             'serial_number' => $this->valueOrNull($data, 'serial_number'),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ]);
 
         LogAccountAudit::dispatch([
@@ -58,7 +56,6 @@ class CreateHardware extends BaseService
                 'hardware_id' => $hardware->id,
                 'hardware_name' => $hardware->name,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         return $hardware;

--- a/app/Services/Company/Adminland/Hardware/DestroyHardware.php
+++ b/app/Services/Company/Adminland/Hardware/DestroyHardware.php
@@ -21,7 +21,6 @@ class DestroyHardware extends BaseService
             'company_id' => 'required|integer|exists:companies,id',
             'author_id' => 'required|integer|exists:employees,id',
             'hardware_id' => 'required|integer|exists:hardware,id',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -55,7 +54,6 @@ class DestroyHardware extends BaseService
             'objects' => json_encode([
                 'hardware_name' => $hardware->name,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         return true;

--- a/app/Services/Company/Adminland/Hardware/LendHardware.php
+++ b/app/Services/Company/Adminland/Hardware/LendHardware.php
@@ -24,7 +24,6 @@ class LendHardware extends BaseService
             'author_id' => 'required|integer|exists:employees,id',
             'employee_id' => 'required|integer|exists:employees,id',
             'hardware_id' => 'required|integer|exists:hardware,id',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -75,7 +74,6 @@ class LendHardware extends BaseService
                 'hardware_name' => $hardware->name,
                 'employee_name' => $this->employee->name,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
     }
 }

--- a/app/Services/Company/Adminland/Hardware/RegainHardware.php
+++ b/app/Services/Company/Adminland/Hardware/RegainHardware.php
@@ -23,7 +23,6 @@ class RegainHardware extends BaseService
             'company_id' => 'required|integer|exists:companies,id',
             'author_id' => 'required|integer|exists:employees,id',
             'hardware_id' => 'required|integer|exists:hardware,id',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -74,7 +73,6 @@ class RegainHardware extends BaseService
                 'hardware_name' => $hardware->name,
                 'employee_name' => $this->employee->name,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
     }
 }

--- a/app/Services/Company/Adminland/Hardware/UpdateHardware.php
+++ b/app/Services/Company/Adminland/Hardware/UpdateHardware.php
@@ -61,7 +61,6 @@ class UpdateHardware extends BaseService
                 'hardware_name' => $hardware->name,
                 'hardware_old_name' => $oldName,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         $hardware->refresh();

--- a/app/Services/Company/Adminland/Hardware/UpdateHardware.php
+++ b/app/Services/Company/Adminland/Hardware/UpdateHardware.php
@@ -22,7 +22,6 @@ class UpdateHardware extends BaseService
             'hardware_id' => 'required|integer|exists:hardware,id',
             'name' => 'required|string|max:255',
             'serial_number' => 'nullable|string|max:255',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 

--- a/app/Services/Company/Adminland/Position/CreatePosition.php
+++ b/app/Services/Company/Adminland/Position/CreatePosition.php
@@ -20,7 +20,6 @@ class CreatePosition extends BaseService
             'company_id' => 'required|integer|exists:companies,id',
             'author_id' => 'required|integer|exists:employees,id',
             'title' => 'required|string|max:255',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -43,7 +42,6 @@ class CreatePosition extends BaseService
         $position = Position::create([
             'company_id' => $data['company_id'],
             'title' => $data['title'],
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ]);
 
         LogAccountAudit::dispatch([
@@ -56,7 +54,6 @@ class CreatePosition extends BaseService
                 'position_id' => $position->id,
                 'position_title' => $position->title,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         return $position;

--- a/app/Services/Company/Adminland/Position/DestroyPosition.php
+++ b/app/Services/Company/Adminland/Position/DestroyPosition.php
@@ -20,7 +20,6 @@ class DestroyPosition extends BaseService
             'company_id' => 'required|integer|exists:companies,id',
             'author_id' => 'required|integer|exists:employees,id',
             'position_id' => 'required|integer|exists:positions,id',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -54,7 +53,6 @@ class DestroyPosition extends BaseService
             'objects' => json_encode([
                 'position_title' => $position->title,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         return true;

--- a/app/Services/Company/Adminland/Position/UpdatePosition.php
+++ b/app/Services/Company/Adminland/Position/UpdatePosition.php
@@ -21,7 +21,6 @@ class UpdatePosition extends BaseService
             'author_id' => 'required|integer|exists:employees,id',
             'position_id' => 'required|integer|exists:positions,id',
             'title' => 'required|string|max:255',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -60,7 +59,6 @@ class UpdatePosition extends BaseService
                 'position_title' => $position->title,
                 'position_old_title' => $oldPositionTitle,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         $position->refresh();

--- a/app/Services/Company/Adminland/Question/ActivateQuestion.php
+++ b/app/Services/Company/Adminland/Question/ActivateQuestion.php
@@ -98,7 +98,6 @@ class ActivateQuestion extends BaseService
                 'question_id' => $question->id,
                 'question_title' => $question->title,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
     }
 }

--- a/app/Services/Company/Adminland/Question/CreateQuestion.php
+++ b/app/Services/Company/Adminland/Question/CreateQuestion.php
@@ -22,7 +22,6 @@ class CreateQuestion extends BaseService
             'author_id' => 'required|integer|exists:employees,id',
             'title' => 'required|string|max:255',
             'active' => 'required|boolean',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -49,7 +48,6 @@ class CreateQuestion extends BaseService
             'company_id' => $data['company_id'],
             'title' => $data['title'],
             'active' => $this->valueOrFalse($data, 'active'),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ]);
 
         LogAccountAudit::dispatch([
@@ -63,7 +61,6 @@ class CreateQuestion extends BaseService
                 'question_title' => $question->title,
                 'question_status' => $question->active,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         return $question;

--- a/app/Services/Company/Adminland/Question/DeactivateQuestion.php
+++ b/app/Services/Company/Adminland/Question/DeactivateQuestion.php
@@ -74,7 +74,6 @@ class DeactivateQuestion extends BaseService
                 'question_id' => $question->id,
                 'question_title' => $question->title,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
     }
 }

--- a/app/Services/Company/Adminland/Question/DestroyQuestion.php
+++ b/app/Services/Company/Adminland/Question/DestroyQuestion.php
@@ -20,7 +20,6 @@ class DestroyQuestion extends BaseService
             'company_id' => 'required|integer|exists:companies,id',
             'author_id' => 'required|integer|exists:employees,id',
             'question_id' => 'required|integer|exists:questions,id',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -54,7 +53,6 @@ class DestroyQuestion extends BaseService
             'objects' => json_encode([
                 'question_title' => $question->title,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         return true;

--- a/app/Services/Company/Adminland/Question/UpdateQuestion.php
+++ b/app/Services/Company/Adminland/Question/UpdateQuestion.php
@@ -64,7 +64,6 @@ class UpdateQuestion extends BaseService
                 'question_title' => $question->title,
                 'question_old_title' => $oldQuestionTitle,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         $question->refresh();

--- a/app/Services/Company/Adminland/Team/CreateTeam.php
+++ b/app/Services/Company/Adminland/Team/CreateTeam.php
@@ -24,7 +24,6 @@ class CreateTeam extends BaseService
             'company_id' => 'required|integer|exists:companies,id',
             'author_id' => 'required|integer|exists:employees,id',
             'name' => 'required|string|max:255',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -83,7 +82,6 @@ class CreateTeam extends BaseService
         $this->team = Team::create([
             'company_id' => $data['company_id'],
             'name' => $data['name'],
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ]);
     }
 
@@ -104,7 +102,6 @@ class CreateTeam extends BaseService
                 'team_id' => $this->team->id,
                 'team_name' => $this->team->name,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         LogTeamAudit::dispatch([
@@ -117,7 +114,6 @@ class CreateTeam extends BaseService
                 'team_id' => $this->team->id,
                 'team_name' => $this->team->name,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
     }
 }

--- a/app/Services/Company/Adminland/Team/DestroyTeam.php
+++ b/app/Services/Company/Adminland/Team/DestroyTeam.php
@@ -20,7 +20,6 @@ class DestroyTeam extends BaseService
             'company_id' => 'required|integer|exists:companies,id',
             'author_id' => 'required|integer|exists:employees,id',
             'team_id' => 'required|integer|exists:teams,id',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -53,7 +52,6 @@ class DestroyTeam extends BaseService
             'objects' => json_encode([
                 'team_name' => $team->name,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         return true;

--- a/app/Services/Company/Adminland/Team/UpdateTeam.php
+++ b/app/Services/Company/Adminland/Team/UpdateTeam.php
@@ -23,7 +23,6 @@ class UpdateTeam extends BaseService
             'author_id' => 'required|integer|exists:employees,id',
             'team_id' => 'required|integer|exists:teams,id',
             'name' => 'required|string|max:255',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -97,7 +96,6 @@ class UpdateTeam extends BaseService
                 'team_old_name' => $oldName,
                 'team_new_name' => $data['name'],
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         LogTeamAudit::dispatch([
@@ -110,7 +108,6 @@ class UpdateTeam extends BaseService
                 'team_old_name' => $oldName,
                 'team_new_name' => $data['name'],
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
     }
 }

--- a/app/Services/Company/Employee/Answer/CreateAnswer.php
+++ b/app/Services/Company/Employee/Answer/CreateAnswer.php
@@ -25,7 +25,6 @@ class CreateAnswer extends BaseService
             'employee_id' => 'required|integer|exists:employees,id',
             'question_id' => 'required|integer|exists:questions,id',
             'body' => 'required|string|max:65535',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -72,7 +71,6 @@ class CreateAnswer extends BaseService
                 'question_id' => $question->id,
                 'question_title' => $question->title,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         LogEmployeeAudit::dispatch([
@@ -86,7 +84,6 @@ class CreateAnswer extends BaseService
                 'question_id' => $question->id,
                 'question_title' => $question->title,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         return $answer;

--- a/app/Services/Company/Employee/Answer/DestroyAnswer.php
+++ b/app/Services/Company/Employee/Answer/DestroyAnswer.php
@@ -23,7 +23,6 @@ class DestroyAnswer extends BaseService
             'author_id' => 'required|integer|exists:employees,id',
             'employee_id' => 'required|integer|exists:employees,id',
             'answer_id' => 'required|integer|exists:answers,id',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -62,7 +61,6 @@ class DestroyAnswer extends BaseService
                 'question_id' => $question->id,
                 'question_title' => $question->title,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         LogEmployeeAudit::dispatch([
@@ -75,7 +73,6 @@ class DestroyAnswer extends BaseService
                 'question_id' => $answer->question->id,
                 'question_title' => $answer->question->title,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         return true;

--- a/app/Services/Company/Employee/Answer/UpdateAnswer.php
+++ b/app/Services/Company/Employee/Answer/UpdateAnswer.php
@@ -68,7 +68,6 @@ class UpdateAnswer extends BaseService
                 'question_id' => $answer->question->id,
                 'question_title' => $answer->question->title,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         LogEmployeeAudit::dispatch([
@@ -82,10 +81,10 @@ class UpdateAnswer extends BaseService
                 'question_id' => $answer->question->id,
                 'question_title' => $answer->question->title,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         $answer->refresh();
+
         return $answer;
     }
 }

--- a/app/Services/Company/Employee/Birthdate/SetBirthdate.php
+++ b/app/Services/Company/Employee/Birthdate/SetBirthdate.php
@@ -25,7 +25,6 @@ class SetBirthdate extends BaseService
             'year' => 'required|integer',
             'month' => 'required|integer',
             'day' => 'required|integer',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -83,7 +82,6 @@ class SetBirthdate extends BaseService
                 'employee_name' => $this->employee->name,
                 'birthday' => $date->format('Y-m-d'),
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         LogEmployeeAudit::dispatch([
@@ -95,7 +93,6 @@ class SetBirthdate extends BaseService
             'objects' => json_encode([
                 'birthday' => $date->format('Y-m-d'),
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
     }
 }

--- a/app/Services/Company/Employee/Description/ClearPersonalDescription.php
+++ b/app/Services/Company/Employee/Description/ClearPersonalDescription.php
@@ -21,7 +21,6 @@ class ClearPersonalDescription extends BaseService
             'company_id' => 'required|integer|exists:companies,id',
             'author_id' => 'required|integer|exists:employees,id',
             'employee_id' => 'required|integer|exists:employees,id',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -57,7 +56,6 @@ class ClearPersonalDescription extends BaseService
                 'employee_id' => $employee->id,
                 'employee_name' => $employee->name,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         LogEmployeeAudit::dispatch([
@@ -67,7 +65,6 @@ class ClearPersonalDescription extends BaseService
             'author_name' => $this->author->name,
             'audited_at' => Carbon::now(),
             'objects' => json_encode([]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         return $employee;

--- a/app/Services/Company/Employee/Description/SetPersonalDescription.php
+++ b/app/Services/Company/Employee/Description/SetPersonalDescription.php
@@ -22,7 +22,6 @@ class SetPersonalDescription extends BaseService
             'author_id' => 'required|integer|exists:employees,id',
             'employee_id' => 'required|integer|exists:employees,id',
             'description' => 'required|string|max:65535',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -61,7 +60,6 @@ class SetPersonalDescription extends BaseService
                 'employee_id' => $employee->id,
                 'employee_name' => $employee->name,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         LogEmployeeAudit::dispatch([
@@ -71,7 +69,6 @@ class SetPersonalDescription extends BaseService
             'author_name' => $this->author->name,
             'audited_at' => Carbon::now(),
             'objects' => json_encode([]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         return $employee;

--- a/app/Services/Company/Employee/EmployeeStatus/AssignEmployeeStatusToEmployee.php
+++ b/app/Services/Company/Employee/EmployeeStatus/AssignEmployeeStatusToEmployee.php
@@ -23,7 +23,6 @@ class AssignEmployeeStatusToEmployee extends BaseService
             'author_id' => 'required|integer|exists:employees,id',
             'employee_id' => 'required|integer|exists:employees,id',
             'employee_status_id' => 'required|integer|exists:employee_statuses,id',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -70,7 +69,6 @@ class AssignEmployeeStatusToEmployee extends BaseService
                 'employee_status_id' => $status->id,
                 'employee_status_name' => $status->name,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         LogEmployeeAudit::dispatch([
@@ -83,7 +81,6 @@ class AssignEmployeeStatusToEmployee extends BaseService
                 'employee_status_id' => $status->id,
                 'employee_status_name' => $status->name,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
     }
 }

--- a/app/Services/Company/Employee/EmployeeStatus/RemoveEmployeeStatusFromEmployee.php
+++ b/app/Services/Company/Employee/EmployeeStatus/RemoveEmployeeStatusFromEmployee.php
@@ -21,7 +21,6 @@ class RemoveEmployeeStatusFromEmployee extends BaseService
             'company_id' => 'required|integer|exists:companies,id',
             'author_id' => 'required|integer|exists:employees,id',
             'employee_id' => 'required|integer|exists:employees,id',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -60,7 +59,6 @@ class RemoveEmployeeStatusFromEmployee extends BaseService
                 'employee_status_id' => $employeeStatus->id,
                 'employee_status_name' => $employeeStatus->name,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         LogEmployeeAudit::dispatch([
@@ -73,7 +71,6 @@ class RemoveEmployeeStatusFromEmployee extends BaseService
                 'employee_status_id' => $employeeStatus->id,
                 'employee_status_name' => $employeeStatus->name,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         $employee->refresh();

--- a/app/Services/Company/Employee/Expense/AcceptExpenseAsAccountant.php
+++ b/app/Services/Company/Employee/Expense/AcceptExpenseAsAccountant.php
@@ -29,7 +29,6 @@ class AcceptExpenseAsAccountant extends BaseService
             'company_id' => 'required|integer|exists:companies,id',
             'author_id' => 'required|integer|exists:employees,id',
             'expense_id' => 'required|integer|exists:expenses,id',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -105,7 +104,6 @@ class AcceptExpenseAsAccountant extends BaseService
             'objects' => json_encode([
                 'title' => $this->expense->title,
             ]),
-            'is_dummy' => $this->valueOrFalse($this->data, 'is_dummy'),
         ])->onQueue('low');
     }
 
@@ -128,7 +126,6 @@ class AcceptExpenseAsAccountant extends BaseService
                 'expense_amount' => MoneyHelper::format($this->expense->amount, $this->expense->currency),
                 'expensed_at' => $this->expense->expensed_at,
             ]),
-            'is_dummy' => $this->valueOrFalse($this->data, 'is_dummy'),
         ])->onQueue('low');
 
         LogEmployeeAudit::dispatch([
@@ -145,7 +142,6 @@ class AcceptExpenseAsAccountant extends BaseService
                 'expense_amount' => MoneyHelper::format($this->expense->amount, $this->expense->currency),
                 'expensed_at' => $this->expense->expensed_at,
             ]),
-            'is_dummy' => $this->valueOrFalse($this->data, 'is_dummy'),
         ])->onQueue('low');
 
         if ($this->expense->employee) {
@@ -161,7 +157,6 @@ class AcceptExpenseAsAccountant extends BaseService
                     'expense_amount' => MoneyHelper::format($this->expense->amount, $this->expense->currency),
                     'expensed_at' => $this->expense->expensed_at,
                 ]),
-                'is_dummy' => $this->valueOrFalse($this->data, 'is_dummy'),
             ])->onQueue('low');
         }
     }

--- a/app/Services/Company/Employee/Expense/AcceptExpenseAsManager.php
+++ b/app/Services/Company/Employee/Expense/AcceptExpenseAsManager.php
@@ -29,7 +29,6 @@ class AcceptExpenseAsManager extends BaseService
             'company_id' => 'required|integer|exists:companies,id',
             'author_id' => 'required|integer|exists:employees,id',
             'expense_id' => 'required|integer|exists:expenses,id',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -112,7 +111,6 @@ class AcceptExpenseAsManager extends BaseService
             'objects' => json_encode([
                 'title' => $this->expense->title,
             ]),
-            'is_dummy' => $this->valueOrFalse($this->data, 'is_dummy'),
         ])->onQueue('low');
     }
 
@@ -135,7 +133,6 @@ class AcceptExpenseAsManager extends BaseService
                 'expense_amount' => MoneyHelper::format($this->expense->amount, $this->expense->currency),
                 'expensed_at' => $this->expense->expensed_at,
             ]),
-            'is_dummy' => $this->valueOrFalse($this->data, 'is_dummy'),
         ])->onQueue('low');
 
         LogEmployeeAudit::dispatch([
@@ -152,7 +149,6 @@ class AcceptExpenseAsManager extends BaseService
                 'expense_amount' => MoneyHelper::format($this->expense->amount, $this->expense->currency),
                 'expensed_at' => $this->expense->expensed_at,
             ]),
-            'is_dummy' => $this->valueOrFalse($this->data, 'is_dummy'),
         ])->onQueue('low');
 
         if ($this->expense->employee) {
@@ -168,7 +164,6 @@ class AcceptExpenseAsManager extends BaseService
                     'expense_amount' => MoneyHelper::format($this->expense->amount, $this->expense->currency),
                     'expensed_at' => $this->expense->expensed_at,
                 ]),
-                'is_dummy' => $this->valueOrFalse($this->data, 'is_dummy'),
             ])->onQueue('low');
         }
     }

--- a/app/Services/Company/Employee/Expense/CreateExpense.php
+++ b/app/Services/Company/Employee/Expense/CreateExpense.php
@@ -42,7 +42,6 @@ class CreateExpense extends BaseService
             'currency' => 'required|string|max:255',
             'description' => 'nullable|string|max:65535',
             'expensed_at' => 'required|date',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -106,7 +105,6 @@ class CreateExpense extends BaseService
             'description' => $this->valueOrNull($this->data, 'description'),
             'expensed_at' => $this->data['expensed_at'],
             'status' => $this->managers->count() > 0 ? Expense::AWAITING_MANAGER_APPROVAL : Expense::AWAITING_ACCOUTING_APPROVAL,
-            'is_dummy' => $this->valueOrFalse($this->data, 'is_dummy'),
         ]);
     }
 
@@ -147,7 +145,6 @@ class CreateExpense extends BaseService
                 'expense_amount' => MoneyHelper::format($this->expense->amount, $this->expense->currency),
                 'expensed_at' => $this->expense->expensed_at,
             ]),
-            'is_dummy' => $this->valueOrFalse($this->data, 'is_dummy'),
         ])->onQueue('low');
 
         LogEmployeeAudit::dispatch([
@@ -162,7 +159,6 @@ class CreateExpense extends BaseService
                 'expense_amount' => MoneyHelper::format($this->expense->amount, $this->expense->currency),
                 'expensed_at' => $this->expense->expensed_at,
             ]),
-            'is_dummy' => $this->valueOrFalse($this->data, 'is_dummy'),
         ])->onQueue('low');
     }
 }

--- a/app/Services/Company/Employee/Expense/RejectExpenseAsAccountant.php
+++ b/app/Services/Company/Employee/Expense/RejectExpenseAsAccountant.php
@@ -30,7 +30,6 @@ class RejectExpenseAsAccountant extends BaseService
             'author_id' => 'required|integer|exists:employees,id',
             'expense_id' => 'required|integer|exists:expenses,id',
             'reason' => 'required|string|max:65535',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -107,7 +106,6 @@ class RejectExpenseAsAccountant extends BaseService
             'objects' => json_encode([
                 'title' => $this->expense->title,
             ]),
-            'is_dummy' => $this->valueOrFalse($this->data, 'is_dummy'),
         ])->onQueue('low');
     }
 
@@ -130,7 +128,6 @@ class RejectExpenseAsAccountant extends BaseService
                 'expense_amount' => MoneyHelper::format($this->expense->amount, $this->expense->currency),
                 'expensed_at' => $this->expense->expensed_at,
             ]),
-            'is_dummy' => $this->valueOrFalse($this->data, 'is_dummy'),
         ])->onQueue('low');
 
         LogEmployeeAudit::dispatch([
@@ -147,7 +144,6 @@ class RejectExpenseAsAccountant extends BaseService
                 'expense_amount' => MoneyHelper::format($this->expense->amount, $this->expense->currency),
                 'expensed_at' => $this->expense->expensed_at,
             ]),
-            'is_dummy' => $this->valueOrFalse($this->data, 'is_dummy'),
         ])->onQueue('low');
 
         if ($this->expense->employee) {
@@ -163,7 +159,6 @@ class RejectExpenseAsAccountant extends BaseService
                     'expense_amount' => MoneyHelper::format($this->expense->amount, $this->expense->currency),
                     'expensed_at' => $this->expense->expensed_at,
                 ]),
-                'is_dummy' => $this->valueOrFalse($this->data, 'is_dummy'),
             ])->onQueue('low');
         }
     }

--- a/app/Services/Company/Employee/Expense/RejectExpenseAsManager.php
+++ b/app/Services/Company/Employee/Expense/RejectExpenseAsManager.php
@@ -30,7 +30,6 @@ class RejectExpenseAsManager extends BaseService
             'author_id' => 'required|integer|exists:employees,id',
             'expense_id' => 'required|integer|exists:expenses,id',
             'reason' => 'required|string|max:65535',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -111,7 +110,6 @@ class RejectExpenseAsManager extends BaseService
             'objects' => json_encode([
                 'title' => $this->expense->title,
             ]),
-            'is_dummy' => $this->valueOrFalse($this->data, 'is_dummy'),
         ])->onQueue('low');
     }
 
@@ -134,7 +132,6 @@ class RejectExpenseAsManager extends BaseService
                 'expense_amount' => MoneyHelper::format($this->expense->amount, $this->expense->currency),
                 'expensed_at' => $this->expense->expensed_at,
             ]),
-            'is_dummy' => $this->valueOrFalse($this->data, 'is_dummy'),
         ])->onQueue('low');
 
         LogEmployeeAudit::dispatch([
@@ -151,7 +148,6 @@ class RejectExpenseAsManager extends BaseService
                 'expense_amount' => MoneyHelper::format($this->expense->amount, $this->expense->currency),
                 'expensed_at' => $this->expense->expensed_at,
             ]),
-            'is_dummy' => $this->valueOrFalse($this->data, 'is_dummy'),
         ])->onQueue('low');
 
         if ($this->expense->employee) {
@@ -167,7 +163,6 @@ class RejectExpenseAsManager extends BaseService
                     'expense_amount' => MoneyHelper::format($this->expense->amount, $this->expense->currency),
                     'expensed_at' => $this->expense->expensed_at,
                 ]),
-                'is_dummy' => $this->valueOrFalse($this->data, 'is_dummy'),
             ])->onQueue('low');
         }
     }

--- a/app/Services/Company/Employee/HiringDate/SetHiringDate.php
+++ b/app/Services/Company/Employee/HiringDate/SetHiringDate.php
@@ -25,7 +25,6 @@ class SetHiringDate extends BaseService
             'year' => 'required|integer',
             'month' => 'required|integer',
             'day' => 'required|integer',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -83,7 +82,6 @@ class SetHiringDate extends BaseService
                 'employee_name' => $this->employee->name,
                 'hiring_date' => $date->format('Y-m-d'),
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         LogEmployeeAudit::dispatch([
@@ -95,7 +93,6 @@ class SetHiringDate extends BaseService
             'objects' => json_encode([
                 'hiring_date' => $date->format('Y-m-d'),
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
     }
 }

--- a/app/Services/Company/Employee/Holiday/CreateTimeOff.php
+++ b/app/Services/Company/Employee/Holiday/CreateTimeOff.php
@@ -33,7 +33,6 @@ class CreateTimeOff extends BaseService
                     'pto',
                 ]),
             'full' => 'required|boolean',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -176,7 +175,6 @@ class CreateTimeOff extends BaseService
                 'planned_holiday_id' => $plannedHoliday->id,
                 'planned_holiday_date' => $plannedHoliday->planned_date,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         LogEmployeeAudit::dispatch([
@@ -189,7 +187,6 @@ class CreateTimeOff extends BaseService
                 'planned_holiday_id' => $plannedHoliday->id,
                 'planned_holiday_date' => $plannedHoliday->planned_date,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
     }
 }

--- a/app/Services/Company/Employee/Holiday/DestroyTimeOff.php
+++ b/app/Services/Company/Employee/Holiday/DestroyTimeOff.php
@@ -54,7 +54,6 @@ class DestroyTimeOff extends BaseService
             'objects' => json_encode([
                 'planned_holiday_date' => $holiday->planned_date,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         LogEmployeeAudit::dispatch([
@@ -66,7 +65,6 @@ class DestroyTimeOff extends BaseService
             'objects' => json_encode([
                 'planned_holiday_date' => $holiday->planned_date,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         return true;

--- a/app/Services/Company/Employee/Holiday/ProcessDailyTimeOffBalance.php
+++ b/app/Services/Company/Employee/Holiday/ProcessDailyTimeOffBalance.php
@@ -20,7 +20,6 @@ class ProcessDailyTimeOffBalance extends BaseService
         return [
             'employee_id' => 'required|integer|exists:employees,id',
             'date' => 'required|date_format:Y-m-d',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -57,7 +56,6 @@ class ProcessDailyTimeOffBalance extends BaseService
             'daily_accrued_amount' => $holidaysEarnedEachDay,
             'current_holidays_per_year' => $employee->amount_of_allowed_holidays,
             'default_amount_of_allowed_holidays_in_company' => $ptoPolicy->default_amount_of_allowed_holidays,
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ]);
 
         $employee->holiday_balance = $newBalance;

--- a/app/Services/Company/Employee/Manager/AssignManager.php
+++ b/app/Services/Company/Employee/Manager/AssignManager.php
@@ -25,7 +25,6 @@ class AssignManager extends BaseService
             'author_id' => 'required|integer|exists:employees,id',
             'employee_id' => 'required|integer|exists:employees,id',
             'manager_id' => 'required|integer|exists:employees,id',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -82,7 +81,6 @@ class AssignManager extends BaseService
                 'employee_id' => $employee->id,
                 'employee_name' => $employee->name,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         // Log information about the employee having a manager assigned
@@ -97,7 +95,6 @@ class AssignManager extends BaseService
                 'manager_id' => $manager->id,
                 'manager_name' => $manager->name,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         // Log information about the manager having assigned a direct report
@@ -111,7 +108,6 @@ class AssignManager extends BaseService
                 'direct_report_id' => $employee->id,
                 'direct_report_name' => $employee->name,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
     }
 }

--- a/app/Services/Company/Employee/Manager/UnassignManager.php
+++ b/app/Services/Company/Employee/Manager/UnassignManager.php
@@ -24,7 +24,6 @@ class UnassignManager extends BaseService
             'author_id' => 'required|integer|exists:employees,id',
             'employee_id' => 'required|integer|exists:employees,id',
             'manager_id' => 'required|integer|exists:employees,id',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -78,7 +77,6 @@ class UnassignManager extends BaseService
                 'employee_id' => $employee->id,
                 'employee_name' => $employee->name,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         // Log information about the employee having a manager assigned
@@ -92,7 +90,6 @@ class UnassignManager extends BaseService
                 'manager_id' => $manager->id,
                 'manager_name' => $manager->name,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         // Log information about the manager having assigned a direct report
@@ -106,7 +103,6 @@ class UnassignManager extends BaseService
                 'direct_report_id' => $employee->id,
                 'direct_report_name' => $employee->name,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
     }
 }

--- a/app/Services/Company/Employee/Morale/LogMorale.php
+++ b/app/Services/Company/Employee/Morale/LogMorale.php
@@ -32,7 +32,6 @@ class LogMorale extends BaseService
                 ]),
             'comment' => 'nullable|string|max:65535',
             'date' => 'nullable|date_format:Y-m-d',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -66,7 +65,6 @@ class LogMorale extends BaseService
             'emotion' => $data['emotion'],
             'comment' => $this->valueOrNull($data, 'comment'),
             'created_at' => $this->valueOrNow($data, 'date'),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ]);
 
         LogAccountAudit::dispatch([
@@ -81,7 +79,6 @@ class LogMorale extends BaseService
                 'morale_id' => $morale->id,
                 'emotion' => $morale->emotion,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         LogEmployeeAudit::dispatch([
@@ -96,7 +93,6 @@ class LogMorale extends BaseService
                 'morale_id' => $morale->id,
                 'emotion' => $morale->emotion,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         return $morale;

--- a/app/Services/Company/Employee/Notification/AddNotificationInUIForEmployee.php
+++ b/app/Services/Company/Employee/Notification/AddNotificationInUIForEmployee.php
@@ -39,7 +39,6 @@ class AddNotificationInUIForEmployee extends BaseService
                 'max:255',
             ],
             'objects' => 'required|json',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -60,7 +59,6 @@ class AddNotificationInUIForEmployee extends BaseService
             'employee_id' => $data['employee_id'],
             'action' => $data['action'],
             'objects' => $data['objects'],
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ]);
 
         return $notification;

--- a/app/Services/Company/Employee/OneOnOne/CreateOneOnOneActionItem.php
+++ b/app/Services/Company/Employee/OneOnOne/CreateOneOnOneActionItem.php
@@ -93,7 +93,6 @@ class CreateOneOnOneActionItem extends BaseService
                 'manager_id' => $this->entry->manager->id,
                 'manager_name' => $this->entry->manager->id,
             ]),
-            'is_dummy' => false,
         ])->onQueue('low');
 
         LogEmployeeAudit::dispatch([
@@ -109,7 +108,6 @@ class CreateOneOnOneActionItem extends BaseService
                 'employee_id' => $this->entry->manager->id,
                 'employee_name' => $this->entry->manager->id,
             ]),
-            'is_dummy' => false,
         ])->onQueue('low');
 
         LogEmployeeAudit::dispatch([
@@ -125,7 +123,6 @@ class CreateOneOnOneActionItem extends BaseService
                 'employee_id' => $this->entry->employee->id,
                 'employee_name' => $this->entry->employee->id,
             ]),
-            'is_dummy' => false,
         ])->onQueue('low');
     }
 }

--- a/app/Services/Company/Employee/OneOnOne/CreateOneOnOneEntry.php
+++ b/app/Services/Company/Employee/OneOnOne/CreateOneOnOneEntry.php
@@ -148,7 +148,6 @@ class CreateOneOnOneEntry extends BaseService
                 'manager_id' => $this->data['manager_id'],
                 'manager_name' => $this->manager->name,
             ]),
-            'is_dummy' => false,
         ])->onQueue('low');
 
         LogEmployeeAudit::dispatch([
@@ -162,7 +161,6 @@ class CreateOneOnOneEntry extends BaseService
                 'employee_id' => $this->data['manager_id'],
                 'employee_name' => $this->manager->name,
             ]),
-            'is_dummy' => false,
         ])->onQueue('low');
 
         LogEmployeeAudit::dispatch([
@@ -176,7 +174,6 @@ class CreateOneOnOneEntry extends BaseService
                 'employee_id' => $this->data['employee_id'],
                 'employee_name' => $this->employee->name,
             ]),
-            'is_dummy' => false,
         ])->onQueue('low');
     }
 }

--- a/app/Services/Company/Employee/OneOnOne/CreateOneOnOneNote.php
+++ b/app/Services/Company/Employee/OneOnOne/CreateOneOnOneNote.php
@@ -90,7 +90,6 @@ class CreateOneOnOneNote extends BaseService
                 'manager_id' => $this->entry->manager->id,
                 'manager_name' => $this->entry->manager->name,
             ]),
-            'is_dummy' => false,
         ])->onQueue('low');
 
         LogEmployeeAudit::dispatch([
@@ -106,7 +105,6 @@ class CreateOneOnOneNote extends BaseService
                 'employee_id' => $this->entry->manager->id,
                 'employee_name' => $this->entry->manager->name,
             ]),
-            'is_dummy' => false,
         ])->onQueue('low');
 
         LogEmployeeAudit::dispatch([
@@ -122,7 +120,6 @@ class CreateOneOnOneNote extends BaseService
                 'employee_id' => $this->entry->employee->id,
                 'employee_name' => $this->entry->employee->name,
             ]),
-            'is_dummy' => false,
         ])->onQueue('low');
     }
 }

--- a/app/Services/Company/Employee/OneOnOne/CreateOneOnOneTalkingPoint.php
+++ b/app/Services/Company/Employee/OneOnOne/CreateOneOnOneTalkingPoint.php
@@ -93,7 +93,6 @@ class CreateOneOnOneTalkingPoint extends BaseService
                 'manager_id' => $this->entry->manager->id,
                 'manager_name' => $this->entry->manager->name,
             ]),
-            'is_dummy' => false,
         ])->onQueue('low');
 
         LogEmployeeAudit::dispatch([
@@ -109,7 +108,6 @@ class CreateOneOnOneTalkingPoint extends BaseService
                 'employee_id' => $this->entry->manager->id,
                 'employee_name' => $this->entry->manager->name,
             ]),
-            'is_dummy' => false,
         ])->onQueue('low');
 
         LogEmployeeAudit::dispatch([
@@ -125,7 +123,6 @@ class CreateOneOnOneTalkingPoint extends BaseService
                 'employee_id' => $this->entry->employee->id,
                 'employee_name' => $this->entry->employee->name,
             ]),
-            'is_dummy' => false,
         ])->onQueue('low');
     }
 }

--- a/app/Services/Company/Employee/OneOnOne/DestroyOneOnOneActionItem.php
+++ b/app/Services/Company/Employee/OneOnOne/DestroyOneOnOneActionItem.php
@@ -88,7 +88,6 @@ class DestroyOneOnOneActionItem extends BaseService
                 'manager_id' => $this->entry->manager->id,
                 'manager_name' => $this->entry->manager->name,
             ]),
-            'is_dummy' => false,
         ])->onQueue('low');
 
         LogEmployeeAudit::dispatch([
@@ -103,7 +102,6 @@ class DestroyOneOnOneActionItem extends BaseService
                 'employee_id' => $this->entry->manager->id,
                 'employee_name' => $this->entry->manager->name,
             ]),
-            'is_dummy' => false,
         ])->onQueue('low');
 
         LogEmployeeAudit::dispatch([
@@ -118,7 +116,6 @@ class DestroyOneOnOneActionItem extends BaseService
                 'employee_id' => $this->entry->employee->id,
                 'employee_name' => $this->entry->employee->name,
             ]),
-            'is_dummy' => false,
         ])->onQueue('low');
     }
 }

--- a/app/Services/Company/Employee/OneOnOne/DestroyOneOnOneEntry.php
+++ b/app/Services/Company/Employee/OneOnOne/DestroyOneOnOneEntry.php
@@ -80,7 +80,6 @@ class DestroyOneOnOneEntry extends BaseService
                 'manager_id' => $this->entry->manager->id,
                 'manager_name' => $this->entry->manager->name,
             ]),
-            'is_dummy' => false,
         ])->onQueue('low');
 
         LogEmployeeAudit::dispatch([
@@ -94,7 +93,6 @@ class DestroyOneOnOneEntry extends BaseService
                 'employee_id' => $this->entry->manager->id,
                 'employee_name' => $this->entry->manager->name,
             ]),
-            'is_dummy' => false,
         ])->onQueue('low');
 
         LogEmployeeAudit::dispatch([
@@ -108,7 +106,6 @@ class DestroyOneOnOneEntry extends BaseService
                 'employee_id' => $this->entry->employee->id,
                 'employee_name' => $this->entry->employee->name,
             ]),
-            'is_dummy' => false,
         ])->onQueue('low');
     }
 }

--- a/app/Services/Company/Employee/OneOnOne/DestroyOneOnOneNote.php
+++ b/app/Services/Company/Employee/OneOnOne/DestroyOneOnOneNote.php
@@ -88,7 +88,6 @@ class DestroyOneOnOneNote extends BaseService
                 'manager_id' => $this->entry->manager->id,
                 'manager_name' => $this->entry->manager->name,
             ]),
-            'is_dummy' => false,
         ])->onQueue('low');
 
         LogEmployeeAudit::dispatch([
@@ -103,7 +102,6 @@ class DestroyOneOnOneNote extends BaseService
                 'employee_id' => $this->entry->manager->id,
                 'employee_name' => $this->entry->manager->name,
             ]),
-            'is_dummy' => false,
         ])->onQueue('low');
 
         LogEmployeeAudit::dispatch([
@@ -118,7 +116,6 @@ class DestroyOneOnOneNote extends BaseService
                 'employee_id' => $this->entry->employee->id,
                 'employee_name' => $this->entry->employee->name,
             ]),
-            'is_dummy' => false,
         ])->onQueue('low');
     }
 }

--- a/app/Services/Company/Employee/OneOnOne/DestroyOneOnOneTalkingPoint.php
+++ b/app/Services/Company/Employee/OneOnOne/DestroyOneOnOneTalkingPoint.php
@@ -88,7 +88,6 @@ class DestroyOneOnOneTalkingPoint extends BaseService
                 'manager_id' => $this->entry->manager->id,
                 'manager_name' => $this->entry->manager->name,
             ]),
-            'is_dummy' => false,
         ])->onQueue('low');
 
         LogEmployeeAudit::dispatch([
@@ -103,7 +102,6 @@ class DestroyOneOnOneTalkingPoint extends BaseService
                 'employee_id' => $this->entry->manager->id,
                 'employee_name' => $this->entry->manager->name,
             ]),
-            'is_dummy' => false,
         ])->onQueue('low');
 
         LogEmployeeAudit::dispatch([
@@ -118,7 +116,6 @@ class DestroyOneOnOneTalkingPoint extends BaseService
                 'employee_id' => $this->entry->employee->id,
                 'employee_name' => $this->entry->employee->name,
             ]),
-            'is_dummy' => false,
         ])->onQueue('low');
     }
 }

--- a/app/Services/Company/Employee/OneOnOne/MarkOneOnOneEntryAsHappened.php
+++ b/app/Services/Company/Employee/OneOnOne/MarkOneOnOneEntryAsHappened.php
@@ -96,7 +96,6 @@ class MarkOneOnOneEntryAsHappened extends BaseService
                 'manager_id' => $this->entry->manager->id,
                 'manager_name' => $this->entry->manager->name,
             ]),
-            'is_dummy' => false,
         ])->onQueue('low');
 
         LogEmployeeAudit::dispatch([
@@ -111,7 +110,6 @@ class MarkOneOnOneEntryAsHappened extends BaseService
                 'employee_id' => $this->entry->manager->id,
                 'employee_name' => $this->entry->manager->name,
             ]),
-            'is_dummy' => false,
         ])->onQueue('low');
 
         LogEmployeeAudit::dispatch([
@@ -126,7 +124,6 @@ class MarkOneOnOneEntryAsHappened extends BaseService
                 'employee_id' => $this->entry->employee->id,
                 'employee_name' => $this->entry->employee->name,
             ]),
-            'is_dummy' => false,
         ])->onQueue('low');
     }
 }

--- a/app/Services/Company/Employee/PersonalDetails/SetPersonalDetails.php
+++ b/app/Services/Company/Employee/PersonalDetails/SetPersonalDetails.php
@@ -27,7 +27,6 @@ class SetPersonalDetails extends BaseService
             'first_name' => 'required|string|max:255',
             'last_name' => 'required|string|max:255',
             'email' => 'required|email:rfc|max:255',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -80,7 +79,6 @@ class SetPersonalDetails extends BaseService
                 'employee_name' => $this->employee->name,
                 'employee_email' => $this->employee->email,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         LogEmployeeAudit::dispatch([
@@ -93,7 +91,6 @@ class SetPersonalDetails extends BaseService
                 'name' => $this->employee->name,
                 'email' => $this->employee->email,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
     }
 }

--- a/app/Services/Company/Employee/PersonalDetails/SetSlackHandle.php
+++ b/app/Services/Company/Employee/PersonalDetails/SetSlackHandle.php
@@ -66,7 +66,6 @@ class SetSlackHandle extends BaseService
                     'employee_name' => $this->employee->name,
                     'slack' => $this->valueOrNull($data, 'slack'),
                 ]),
-                'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
             ])->onQueue('low');
 
             LogEmployeeAudit::dispatch([
@@ -78,7 +77,6 @@ class SetSlackHandle extends BaseService
                 'objects' => json_encode([
                     'slack' => $this->valueOrNull($data, 'slack'),
                 ]),
-                'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
             ])->onQueue('low');
         }
 
@@ -93,7 +91,6 @@ class SetSlackHandle extends BaseService
                     'employee_id' => $this->employee->id,
                     'employee_name' => $this->employee->name,
                 ]),
-                'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
             ])->onQueue('low');
 
             LogEmployeeAudit::dispatch([
@@ -103,7 +100,6 @@ class SetSlackHandle extends BaseService
                 'author_name' => $this->author->name,
                 'audited_at' => Carbon::now(),
                 'objects' => json_encode([]),
-                'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
             ])->onQueue('low');
         }
     }

--- a/app/Services/Company/Employee/PersonalDetails/SetTwitterHandle.php
+++ b/app/Services/Company/Employee/PersonalDetails/SetTwitterHandle.php
@@ -66,7 +66,6 @@ class SetTwitterHandle extends BaseService
                     'employee_name' => $this->employee->name,
                     'twitter' => $this->valueOrNull($data, 'twitter'),
                 ]),
-                'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
             ])->onQueue('low');
 
             LogEmployeeAudit::dispatch([
@@ -78,7 +77,6 @@ class SetTwitterHandle extends BaseService
                 'objects' => json_encode([
                     'twitter' => $this->valueOrNull($data, 'twitter'),
                 ]),
-                'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
             ])->onQueue('low');
         }
 
@@ -93,7 +91,6 @@ class SetTwitterHandle extends BaseService
                     'employee_id' => $this->employee->id,
                     'employee_name' => $this->employee->name,
                 ]),
-                'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
             ])->onQueue('low');
 
             LogEmployeeAudit::dispatch([
@@ -103,7 +100,6 @@ class SetTwitterHandle extends BaseService
                 'author_name' => $this->author->name,
                 'audited_at' => Carbon::now(),
                 'objects' => json_encode([]),
-                'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
             ])->onQueue('low');
         }
     }

--- a/app/Services/Company/Employee/Position/AssignPositionToEmployee.php
+++ b/app/Services/Company/Employee/Position/AssignPositionToEmployee.php
@@ -23,7 +23,6 @@ class AssignPositionToEmployee extends BaseService
             'author_id' => 'required|integer|exists:employees,id',
             'employee_id' => 'required|integer|exists:employees,id',
             'position_id' => 'required|integer|exists:positions,id',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -63,7 +62,6 @@ class AssignPositionToEmployee extends BaseService
                 'position_id' => $position->id,
                 'position_title' => $position->title,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         LogEmployeeAudit::dispatch([
@@ -76,7 +74,6 @@ class AssignPositionToEmployee extends BaseService
                 'position_id' => $position->id,
                 'position_title' => $position->title,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         return $employee;

--- a/app/Services/Company/Employee/Position/RemovePositionFromEmployee.php
+++ b/app/Services/Company/Employee/Position/RemovePositionFromEmployee.php
@@ -22,7 +22,6 @@ class RemovePositionFromEmployee extends BaseService
             'company_id' => 'required|integer|exists:companies,id',
             'author_id' => 'required|integer|exists:employees,id',
             'employee_id' => 'required|integer|exists:employees,id',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -61,7 +60,6 @@ class RemovePositionFromEmployee extends BaseService
                 'position_id' => $formerPosition->id,
                 'position_title' => $formerPosition->title,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         LogEmployeeAudit::dispatch([
@@ -74,7 +72,6 @@ class RemovePositionFromEmployee extends BaseService
                 'position_id' => $formerPosition->id,
                 'position_title' => $formerPosition->title,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         return $employee;

--- a/app/Services/Company/Employee/Pronoun/AssignPronounToEmployee.php
+++ b/app/Services/Company/Employee/Pronoun/AssignPronounToEmployee.php
@@ -23,7 +23,6 @@ class AssignPronounToEmployee extends BaseService
             'author_id' => 'required|integer|exists:employees,id',
             'employee_id' => 'required|integer|exists:employees,id',
             'pronoun_id' => 'required|integer|exists:pronouns,id',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -63,7 +62,6 @@ class AssignPronounToEmployee extends BaseService
                 'pronoun_id' => $pronoun->id,
                 'pronoun_label' => $pronoun->label,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         LogEmployeeAudit::dispatch([
@@ -76,7 +74,6 @@ class AssignPronounToEmployee extends BaseService
                 'pronoun_id' => $pronoun->id,
                 'pronoun_label' => $pronoun->label,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         return $employee;

--- a/app/Services/Company/Employee/Pronoun/RemovePronounFromEmployee.php
+++ b/app/Services/Company/Employee/Pronoun/RemovePronounFromEmployee.php
@@ -22,7 +22,6 @@ class RemovePronounFromEmployee extends BaseService
             'company_id' => 'required|integer|exists:companies,id',
             'author_id' => 'required|integer|exists:employees,id',
             'employee_id' => 'required|integer|exists:employees,id',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -58,7 +57,6 @@ class RemovePronounFromEmployee extends BaseService
                 'employee_id' => $employee->id,
                 'employee_name' => $employee->name,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         LogEmployeeAudit::dispatch([
@@ -68,7 +66,6 @@ class RemovePronounFromEmployee extends BaseService
             'author_name' => $this->author->name,
             'audited_at' => Carbon::now(),
             'objects' => json_encode([]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         return $employee;

--- a/app/Services/Company/Employee/RateYourManager/AddCommentToRatingAboutManager.php
+++ b/app/Services/Company/Employee/RateYourManager/AddCommentToRatingAboutManager.php
@@ -23,7 +23,6 @@ class AddCommentToRatingAboutManager extends BaseService
             'answer_id' => 'required|integer|exists:rate_your_manager_answers,id',
             'comment' => 'required|string|max:65535',
             'reveal_identity_to_manager' => 'boolean',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 

--- a/app/Services/Company/Employee/RateYourManager/RateYourManager.php
+++ b/app/Services/Company/Employee/RateYourManager/RateYourManager.php
@@ -25,7 +25,6 @@ class RateYourManager extends BaseService
             'author_id' => 'required|integer|exists:employees,id',
             'answer_id' => 'required|integer|exists:rate_your_manager_answers,id',
             'rating' => 'required|string|max:255',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -73,7 +72,6 @@ class RateYourManager extends BaseService
                 'manager_id' => $survey->manager->id,
                 'manager_name' => $survey->manager->name,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         LogEmployeeAudit::dispatch([
@@ -86,7 +84,6 @@ class RateYourManager extends BaseService
                 'manager_id' => $survey->manager->id,
                 'manager_name' => $survey->manager->name,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         return $answer;

--- a/app/Services/Company/Employee/Skill/AttachEmployeeToSkill.php
+++ b/app/Services/Company/Employee/Skill/AttachEmployeeToSkill.php
@@ -30,7 +30,6 @@ class AttachEmployeeToSkill extends BaseService
             'author_id' => 'required|integer|exists:employees,id',
             'employee_id' => 'required|integer|exists:employees,id',
             'name' => 'required|string|max:255',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -91,7 +90,6 @@ class AttachEmployeeToSkill extends BaseService
         $this->skill = Skill::create([
             'company_id' => $this->data['company_id'],
             'name' => $name,
-            'is_dummy' => $this->valueOrFalse($this->data, 'is_dummy'),
         ]);
     }
 
@@ -122,7 +120,6 @@ class AttachEmployeeToSkill extends BaseService
                 'employee_id' => $this->employee->id,
                 'employee_name' => $this->employee->name,
             ]),
-            'is_dummy' => $this->valueOrFalse($this->data, 'is_dummy'),
         ])->onQueue('low');
     }
 
@@ -143,7 +140,6 @@ class AttachEmployeeToSkill extends BaseService
                 'employee_id' => $this->employee->id,
                 'employee_name' => $this->employee->name,
             ]),
-            'is_dummy' => $this->valueOrFalse($this->data, 'is_dummy'),
         ])->onQueue('low');
 
         LogEmployeeAudit::dispatch([
@@ -156,7 +152,6 @@ class AttachEmployeeToSkill extends BaseService
                 'skill_id' => $this->skill->id,
                 'skill_name' => $this->skill->name,
             ]),
-            'is_dummy' => $this->valueOrFalse($this->data, 'is_dummy'),
         ])->onQueue('low');
     }
 
@@ -169,6 +164,7 @@ class AttachEmployeeToSkill extends BaseService
     private function formatName(string $name): string
     {
         $name = StringHelper::removeLettersWithAccent($name);
+
         return strtolower($name);
     }
 }

--- a/app/Services/Company/Employee/Skill/DestroySkill.php
+++ b/app/Services/Company/Employee/Skill/DestroySkill.php
@@ -24,7 +24,6 @@ class DestroySkill extends BaseService
             'company_id' => 'required|integer|exists:companies,id',
             'author_id' => 'required|integer|exists:employees,id',
             'skill_id' => 'required|integer|exists:skills,id',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -73,7 +72,6 @@ class DestroySkill extends BaseService
             'objects' => json_encode([
                 'skill_name' => $this->skill->name,
             ]),
-            'is_dummy' => $this->valueOrFalse($this->data, 'is_dummy'),
         ])->onQueue('low');
     }
 }

--- a/app/Services/Company/Employee/Skill/RemoveSkillFromEmployee.php
+++ b/app/Services/Company/Employee/Skill/RemoveSkillFromEmployee.php
@@ -29,7 +29,6 @@ class RemoveSkillFromEmployee extends BaseService
             'author_id' => 'required|integer|exists:employees,id',
             'employee_id' => 'required|integer|exists:employees,id',
             'skill_id' => 'required|integer|exists:skills,id',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -99,7 +98,6 @@ class RemoveSkillFromEmployee extends BaseService
                 'employee_id' => $this->employee->id,
                 'employee_name' => $this->employee->name,
             ]),
-            'is_dummy' => $this->valueOrFalse($this->data, 'is_dummy'),
         ])->onQueue('low');
 
         LogEmployeeAudit::dispatch([
@@ -112,7 +110,6 @@ class RemoveSkillFromEmployee extends BaseService
                 'skill_id' => $this->skill->id,
                 'skill_name' => $this->skill->name,
             ]),
-            'is_dummy' => $this->valueOrFalse($this->data, 'is_dummy'),
         ])->onQueue('low');
     }
 }

--- a/app/Services/Company/Employee/Skill/UpdateSkill.php
+++ b/app/Services/Company/Employee/Skill/UpdateSkill.php
@@ -27,7 +27,6 @@ class UpdateSkill extends BaseService
             'author_id' => 'required|integer|exists:employees,id',
             'skill_id' => 'required|integer|exists:skills,id',
             'name' => 'required|string|max:255',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -92,7 +91,6 @@ class UpdateSkill extends BaseService
                 'skill_old_name' => $oldName,
                 'skill_new_name' => $newName,
             ]),
-            'is_dummy' => $this->valueOrFalse($this->data, 'is_dummy'),
         ])->onQueue('low');
     }
 
@@ -105,6 +103,7 @@ class UpdateSkill extends BaseService
     private function formatName(string $name): string
     {
         $name = StringHelper::removeLettersWithAccent($name);
+
         return strtolower($name);
     }
 

--- a/app/Services/Company/Employee/Team/AddEmployeeToTeam.php
+++ b/app/Services/Company/Employee/Team/AddEmployeeToTeam.php
@@ -27,7 +27,6 @@ class AddEmployeeToTeam extends BaseService
             'author_id' => 'required|integer|exists:employees,id',
             'employee_id' => 'required|integer|exists:employees,id',
             'team_id' => 'required|integer|exists:teams,id',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -105,7 +104,6 @@ class AddEmployeeToTeam extends BaseService
             'author_name' => $this->author->name,
             'audited_at' => Carbon::now(),
             'objects' => json_encode($dataToLog),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         LogTeamAudit::dispatch([
@@ -115,7 +113,6 @@ class AddEmployeeToTeam extends BaseService
             'author_name' => $this->author->name,
             'audited_at' => Carbon::now(),
             'objects' => json_encode($dataToLog),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         LogEmployeeAudit::dispatch([
@@ -125,7 +122,6 @@ class AddEmployeeToTeam extends BaseService
             'author_name' => $this->author->name,
             'audited_at' => Carbon::now(),
             'objects' => json_encode($dataToLog),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
     }
 }

--- a/app/Services/Company/Employee/Team/RemoveEmployeeFromTeam.php
+++ b/app/Services/Company/Employee/Team/RemoveEmployeeFromTeam.php
@@ -27,7 +27,6 @@ class RemoveEmployeeFromTeam extends BaseService
             'author_id' => 'required|integer|exists:employees,id',
             'employee_id' => 'required|integer|exists:employees,id',
             'team_id' => 'required|integer|exists:teams,id',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -103,7 +102,6 @@ class RemoveEmployeeFromTeam extends BaseService
             'author_name' => $this->author->name,
             'audited_at' => Carbon::now(),
             'objects' => json_encode($dataToLog),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         LogTeamAudit::dispatch([
@@ -113,7 +111,6 @@ class RemoveEmployeeFromTeam extends BaseService
             'author_name' => $this->author->name,
             'audited_at' => Carbon::now(),
             'objects' => json_encode($dataToLog),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         LogEmployeeAudit::dispatch([
@@ -123,7 +120,6 @@ class RemoveEmployeeFromTeam extends BaseService
             'author_name' => $this->author->name,
             'audited_at' => Carbon::now(),
             'objects' => json_encode($dataToLog),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
     }
 }

--- a/app/Services/Company/Employee/WorkFromHome/UpdateWorkFromHomeInformation.php
+++ b/app/Services/Company/Employee/WorkFromHome/UpdateWorkFromHomeInformation.php
@@ -24,7 +24,6 @@ class UpdateWorkFromHomeInformation extends BaseService
             'employee_id' => 'required|integer|exists:employees,id',
             'date' => 'required|date_format:Y-m-d',
             'work_from_home' => 'required|boolean',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -88,7 +87,6 @@ class UpdateWorkFromHomeInformation extends BaseService
                 'employee_name' => $employee->name,
                 'date' => $data['date'],
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         LogEmployeeAudit::dispatch([
@@ -100,7 +98,6 @@ class UpdateWorkFromHomeInformation extends BaseService
             'objects' => json_encode([
                 'date' => $data['date'],
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
     }
 
@@ -117,7 +114,6 @@ class UpdateWorkFromHomeInformation extends BaseService
                 'employee_name' => $employee->name,
                 'date' => $data['date'],
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         LogEmployeeAudit::dispatch([
@@ -129,7 +125,6 @@ class UpdateWorkFromHomeInformation extends BaseService
             'objects' => json_encode([
                 'date' => $data['date'],
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
     }
 }

--- a/app/Services/Company/Employee/Worklog/LogWorklog.php
+++ b/app/Services/Company/Employee/Worklog/LogWorklog.php
@@ -27,7 +27,6 @@ class LogWorklog extends BaseService
             'employee_id' => 'required|integer|exists:employees,id',
             'content' => 'required|string|max:65535',
             'date' => 'nullable|date_format:Y-m-d',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -56,7 +55,6 @@ class LogWorklog extends BaseService
             'employee_id' => $data['employee_id'],
             'content' => $data['content'],
             'created_at' => $this->valueOrNow($data, 'date'),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ]);
 
         $this->log($worklog, $data);
@@ -89,7 +87,6 @@ class LogWorklog extends BaseService
                 'employee_name' => $this->employee->name,
                 'worklog_id' => $worklog->id,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         LogEmployeeAudit::dispatch([
@@ -103,7 +100,6 @@ class LogWorklog extends BaseService
                 'employee_name' => $this->employee->name,
                 'worklog_id' => $worklog->id,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
     }
 }

--- a/app/Services/Company/Place/CreatePlace.php
+++ b/app/Services/Company/Place/CreatePlace.php
@@ -30,7 +30,6 @@ class CreatePlace extends BaseService
             'placable_id' => 'required|integer',
             'placable_type' => 'required|string|max:255',
             'is_active' => 'nullable|boolean',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -83,7 +82,6 @@ class CreatePlace extends BaseService
             'placable_id' => $data['placable_id'],
             'placable_type' => $data['placable_type'],
             'is_active' => $this->valueOrFalse($data, 'is_active'),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ]);
     }
 
@@ -131,7 +129,6 @@ class CreatePlace extends BaseService
                 'place_id' => $place->id,
                 'partial_address' => $place->getPartialAddress(),
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         LogEmployeeAudit::dispatch([
@@ -144,7 +141,6 @@ class CreatePlace extends BaseService
                 'place_id' => $place->id,
                 'partial_address' => $place->getPartialAddress(),
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
     }
 }

--- a/app/Services/Company/Task/CreateTask.php
+++ b/app/Services/Company/Task/CreateTask.php
@@ -33,7 +33,6 @@ class CreateTask extends BaseService
             'completed' => 'nullable|boolean',
             'due_at' => 'nullable|date_format:Y-m-d',
             'completed_at' => 'nullable|date_format:Y-m-d',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -79,7 +78,6 @@ class CreateTask extends BaseService
             'title' => $this->data['title'],
             'due_at' => $this->nullOrDate($this->data, 'due_at'),
             'completed_at' => $this->nullOrDate($this->data, 'completed_at'),
-            'is_dummy' => $this->valueOrFalse($this->data, 'is_dummy'),
         ]);
     }
 
@@ -99,7 +97,6 @@ class CreateTask extends BaseService
                 'employee_name' => $this->employee->name,
                 'title' => $this->data['title'],
             ]),
-            'is_dummy' => $this->valueOrFalse($this->data, 'is_dummy'),
         ])->onQueue('low');
 
         LogEmployeeAudit::dispatch([
@@ -111,7 +108,6 @@ class CreateTask extends BaseService
             'objects' => json_encode([
                 'title' => $this->data['title'],
             ]),
-            'is_dummy' => $this->valueOrFalse($this->data, 'is_dummy'),
         ])->onQueue('low');
     }
 
@@ -130,7 +126,6 @@ class CreateTask extends BaseService
                 'author_name' => $this->author->name,
                 'title' => $this->data['title'],
             ]),
-            'is_dummy' => $this->valueOrFalse($this->data, 'is_dummy'),
         ])->onQueue('low');
     }
 }

--- a/app/Services/Company/Team/Description/ClearTeamDescription.php
+++ b/app/Services/Company/Team/Description/ClearTeamDescription.php
@@ -21,7 +21,6 @@ class ClearTeamDescription extends BaseService
             'company_id' => 'required|integer|exists:companies,id',
             'author_id' => 'required|integer|exists:employees,id',
             'team_id' => 'required|integer|exists:teams,id',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -56,7 +55,6 @@ class ClearTeamDescription extends BaseService
                 'team_id' => $team->id,
                 'team_name' => $team->name,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         LogTeamAudit::dispatch([
@@ -69,7 +67,6 @@ class ClearTeamDescription extends BaseService
                 'team_id' => $team->id,
                 'team_name' => $team->name,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         return $team;

--- a/app/Services/Company/Team/Description/SetTeamDescription.php
+++ b/app/Services/Company/Team/Description/SetTeamDescription.php
@@ -22,7 +22,6 @@ class SetTeamDescription extends BaseService
             'author_id' => 'required|integer|exists:employees,id',
             'team_id' => 'required|integer|exists:teams,id',
             'description' => 'required|string|max:65535',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -60,7 +59,6 @@ class SetTeamDescription extends BaseService
                 'team_id' => $team->id,
                 'team_name' => $team->name,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         LogTeamAudit::dispatch([
@@ -73,7 +71,6 @@ class SetTeamDescription extends BaseService
                 'team_id' => $team->id,
                 'team_name' => $team->name,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         return $team;

--- a/app/Services/Company/Team/Links/CreateTeamUsefulLink.php
+++ b/app/Services/Company/Team/Links/CreateTeamUsefulLink.php
@@ -33,7 +33,6 @@ class CreateTeamUsefulLink extends BaseService
             ],
             'label' => 'nullable|string|max:255',
             'url' => 'required|string|max:255',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -78,7 +77,6 @@ class CreateTeamUsefulLink extends BaseService
             'label' => $this->valueOrNull($data, 'label'),
             'type' => $data['type'],
             'url' => $data['url'],
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ]);
     }
 
@@ -103,7 +101,6 @@ class CreateTeamUsefulLink extends BaseService
                 'team_id' => $team->id,
                 'team_name' => $team->name,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         LogTeamAudit::dispatch([
@@ -116,7 +113,6 @@ class CreateTeamUsefulLink extends BaseService
                 'link_id' => $link->id,
                 'link_name' => $link->label,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
     }
 }

--- a/app/Services/Company/Team/Links/DestroyTeamUsefulLink.php
+++ b/app/Services/Company/Team/Links/DestroyTeamUsefulLink.php
@@ -59,7 +59,6 @@ class DestroyTeamUsefulLink extends BaseService
                 'team_id' => $link->team->id,
                 'team_name' => $link->team->name,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         LogTeamAudit::dispatch([
@@ -71,7 +70,6 @@ class DestroyTeamUsefulLink extends BaseService
             'objects' => json_encode([
                 'link_name' => $link->label,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         return true;

--- a/app/Services/Company/Team/Links/UpdateTeamUsefulLink.php
+++ b/app/Services/Company/Team/Links/UpdateTeamUsefulLink.php
@@ -90,7 +90,6 @@ class UpdateTeamUsefulLink extends BaseService
                 'team_id' => $link->team->id,
                 'team_name' => $link->team->name,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         LogTeamAudit::dispatch([
@@ -103,7 +102,6 @@ class UpdateTeamUsefulLink extends BaseService
                 'link_id' => $link->id,
                 'link_name' => $link->label,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
     }
 }

--- a/app/Services/Company/Team/SetTeamLead.php
+++ b/app/Services/Company/Team/SetTeamLead.php
@@ -29,7 +29,6 @@ class SetTeamLead extends BaseService
             'author_id' => 'required|integer|exists:employees,id',
             'employee_id' => 'required|integer|exists:employees,id',
             'team_id' => 'required|integer|exists:teams,id',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -129,7 +128,6 @@ class SetTeamLead extends BaseService
                 'team_leader_name' => $this->employee->name,
                 'team_name' => $this->team->name,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         LogTeamAudit::dispatch([
@@ -142,7 +140,6 @@ class SetTeamLead extends BaseService
                 'team_leader_id' => $this->employee->id,
                 'team_leader_name' => $this->employee->name,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
     }
 }

--- a/app/Services/Company/Team/Ship/AttachEmployeeToShip.php
+++ b/app/Services/Company/Team/Ship/AttachEmployeeToShip.php
@@ -34,7 +34,6 @@ class AttachEmployeeToShip extends BaseService
             'author_id' => 'required|integer|exists:employees,id',
             'employee_id' => 'required|integer|exists:employees,id',
             'ship_id' => 'required|integer|exists:ships,id',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -115,7 +114,6 @@ class AttachEmployeeToShip extends BaseService
             'author_name' => $this->author->name,
             'audited_at' => Carbon::now(),
             'objects' => json_encode($dataToLog),
-            'is_dummy' => $this->valueOrFalse($this->data, 'is_dummy'),
         ])->onQueue('low');
 
         LogEmployeeAudit::dispatch([
@@ -125,7 +123,6 @@ class AttachEmployeeToShip extends BaseService
             'author_name' => $this->author->name,
             'audited_at' => Carbon::now(),
             'objects' => json_encode($dataToLog),
-            'is_dummy' => $this->valueOrFalse($this->data, 'is_dummy'),
         ])->onQueue('low');
     }
 }

--- a/app/Services/Company/Team/Ship/CreateShip.php
+++ b/app/Services/Company/Team/Ship/CreateShip.php
@@ -32,7 +32,6 @@ class CreateShip extends BaseService
             'title' => 'required|string|max:255',
             'description' => 'nullable|string|max:65535',
             'employees' => 'nullable|array',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -73,7 +72,6 @@ class CreateShip extends BaseService
             'team_id' => $this->data['team_id'],
             'title' => $this->data['title'],
             'description' => $this->valueOrNull($this->data, 'description'),
-            'is_dummy' => $this->valueOrFalse($this->data, 'is_dummy'),
         ]);
     }
 
@@ -93,7 +91,6 @@ class CreateShip extends BaseService
                 'author_id' => $this->data['author_id'],
                 'employee_id' => $employeeId,
                 'ship_id' => $this->ship->id,
-                'is_dummy' => $this->valueOrFalse($this->data, 'is_dummy'),
             ])->onQueue('low');
         }
     }
@@ -115,7 +112,6 @@ class CreateShip extends BaseService
                 'ship_id' => $this->ship->id,
                 'ship_title' => $this->ship->title,
             ]),
-            'is_dummy' => $this->valueOrFalse($this->data, 'is_dummy'),
         ])->onQueue('low');
 
         LogTeamAudit::dispatch([
@@ -128,7 +124,6 @@ class CreateShip extends BaseService
                 'ship_id' => $this->ship->id,
                 'ship_title' => $this->ship->title,
             ]),
-            'is_dummy' => $this->valueOrFalse($this->data, 'is_dummy'),
         ])->onQueue('low');
     }
 }

--- a/app/Services/Company/Team/Ship/DestroyShip.php
+++ b/app/Services/Company/Team/Ship/DestroyShip.php
@@ -59,7 +59,6 @@ class DestroyShip extends BaseService
                 'team_id' => $ship->team->id,
                 'team_name' => $ship->team->name,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         LogTeamAudit::dispatch([
@@ -71,7 +70,6 @@ class DestroyShip extends BaseService
             'objects' => json_encode([
                 'ship_title' => $ship->title,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         return true;

--- a/app/Services/Company/Team/TeamNews/CreateTeamNews.php
+++ b/app/Services/Company/Team/TeamNews/CreateTeamNews.php
@@ -25,7 +25,6 @@ class CreateTeamNews extends BaseService
             'title' => 'required|string|max:255',
             'content' => 'required|string|max:65535',
             'created_at' => 'nullable|date_format:Y-m-d H:i:s',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -53,7 +52,6 @@ class CreateTeamNews extends BaseService
             'author_name' => $this->author->name,
             'title' => $data['title'],
             'content' => $data['content'],
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ]);
 
         if (! empty($data['created_at'])) {
@@ -73,7 +71,6 @@ class CreateTeamNews extends BaseService
                 'team_news_id' => $news->id,
                 'team_news_title' => $news->title,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         LogTeamAudit::dispatch([
@@ -86,7 +83,6 @@ class CreateTeamNews extends BaseService
                 'team_news_id' => $news->id,
                 'team_news_title' => $news->title,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         return $news;

--- a/app/Services/Company/Team/TeamNews/DestroyTeamNews.php
+++ b/app/Services/Company/Team/TeamNews/DestroyTeamNews.php
@@ -22,7 +22,6 @@ class DestroyTeamNews extends BaseService
             'company_id' => 'required|integer|exists:companies,id',
             'author_id' => 'required|integer|exists:employees,id',
             'team_news_id' => 'required|integer|exists:team_news,id',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -62,7 +61,6 @@ class DestroyTeamNews extends BaseService
                 'team_name' => $team->name,
                 'team_news_title' => $news->title,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         LogTeamAudit::dispatch([
@@ -74,7 +72,6 @@ class DestroyTeamNews extends BaseService
             'objects' => json_encode([
                 'team_news_title' => $news->title,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         return true;

--- a/app/Services/Company/Team/TeamNews/UpdateTeamNews.php
+++ b/app/Services/Company/Team/TeamNews/UpdateTeamNews.php
@@ -25,7 +25,6 @@ class UpdateTeamNews extends BaseService
             'team_news_id' => 'required|integer|exists:team_news,id',
             'title' => 'required|string|max:255',
             'content' => 'required|string|max:65535',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -71,7 +70,6 @@ class UpdateTeamNews extends BaseService
                 'team_news_title' => $news->title,
                 'team_news_old_title' => $oldNewsTitle,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         LogTeamAudit::dispatch([
@@ -85,7 +83,6 @@ class UpdateTeamNews extends BaseService
                 'team_news_title' => $news->title,
                 'team_news_old_title' => $oldNewsTitle,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         $news->refresh();

--- a/app/Services/Company/Team/UnsetTeamLead.php
+++ b/app/Services/Company/Team/UnsetTeamLead.php
@@ -23,7 +23,6 @@ class UnsetTeamLead extends BaseService
             'company_id' => 'required|integer|exists:companies,id',
             'author_id' => 'required|integer|exists:employees,id',
             'team_id' => 'required|integer|exists:teams,id',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -93,7 +92,6 @@ class UnsetTeamLead extends BaseService
                 'team_leader_name' => $oldTeamLeader->name,
                 'team_name' => $team->name,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
 
         LogTeamAudit::dispatch([
@@ -105,7 +103,6 @@ class UnsetTeamLead extends BaseService
             'objects' => json_encode([
                 'team_leader_name' => $oldTeamLeader->name,
             ]),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ])->onQueue('low');
     }
 }

--- a/app/Services/Logs/LogAccountAction.php
+++ b/app/Services/Logs/LogAccountAction.php
@@ -22,7 +22,6 @@ class LogAccountAction extends BaseService
             'action' => 'required|string|max:255',
             'objects' => 'required|json',
             'ip_address' => 'nullable|ipv4',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -52,7 +51,6 @@ class LogAccountAction extends BaseService
             'action' => $data['action'],
             'objects' => $data['objects'],
             'ip_address' => $this->valueOrNull($data, 'ip_address'),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ]);
     }
 }

--- a/app/Services/Logs/LogEmployeeAction.php
+++ b/app/Services/Logs/LogEmployeeAction.php
@@ -24,7 +24,6 @@ class LogEmployeeAction extends BaseService
             'action' => 'required|string|max:255',
             'objects' => 'required|json',
             'ip_address' => 'nullable|ipv4',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -55,7 +54,6 @@ class LogEmployeeAction extends BaseService
             'action' => $data['action'],
             'objects' => $data['objects'],
             'ip_address' => $this->valueOrNull($data, 'ip_address'),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ]);
     }
 }

--- a/app/Services/Logs/LogTeamAction.php
+++ b/app/Services/Logs/LogTeamAction.php
@@ -25,7 +25,6 @@ class LogTeamAction extends BaseService
             'action' => 'required|string|max:255',
             'objects' => 'required|json',
             'ip_address' => 'nullable|ipv4',
-            'is_dummy' => 'nullable|boolean',
         ];
     }
 
@@ -55,7 +54,6 @@ class LogTeamAction extends BaseService
             'action' => $data['action'],
             'objects' => $data['objects'],
             'ip_address' => $this->valueOrNull($data, 'ip_address'),
-            'is_dummy' => $this->valueOrFalse($data, 'is_dummy'),
         ]);
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ca51045c45abab70301bd143d770dec9",
+    "content-hash": "23025aaf61c3876bdd3210aeff69d818",
     "packages": [
         {
             "name": "brick/math",

--- a/database/migrations/2019_01_18_194542_create_employees_table.php
+++ b/database/migrations/2019_01_18_194542_create_employees_table.php
@@ -36,7 +36,6 @@ class CreateEmployeesTable extends Migration
             $table->string('default_dashboard_view')->default('me');
             $table->boolean('can_manage_expenses')->default(false);
             $table->boolean('display_welcome_message')->default(false);
-            $table->boolean('is_dummy')->default(false);
             $table->timestamps();
             $table->foreign('user_id')->references('id')->on('users')->onDelete('set null');
             $table->foreign('company_id')->references('id')->on('companies')->onDelete('cascade');

--- a/database/migrations/2019_01_25_133723_create_teams_table.php
+++ b/database/migrations/2019_01_25_133723_create_teams_table.php
@@ -18,7 +18,6 @@ class CreateTeamsTable extends Migration
             $table->id();
             $table->unsignedBigInteger('company_id');
             $table->string('name');
-            $table->boolean('is_dummy')->default(false);
             $table->timestamps();
             $table->foreign('company_id')->references('id')->on('companies')->onDelete('cascade');
             $table->index('name');

--- a/database/migrations/2019_01_26_181403_create_audit_log_table.php
+++ b/database/migrations/2019_01_26_181403_create_audit_log_table.php
@@ -23,7 +23,6 @@ class CreateAuditLogTable extends Migration
             $table->text('objects');
             $table->datetime('audited_at');
             $table->string('ip_address')->nullable();
-            $table->boolean('is_dummy')->default(false);
             $table->timestamps();
             $table->foreign('company_id')->references('id')->on('companies')->onDelete('cascade');
             $table->foreign('author_id')->references('id')->on('employees')->onDelete('set null');

--- a/database/migrations/2019_03_30_185805_create_employee_log_table.php
+++ b/database/migrations/2019_03_30_185805_create_employee_log_table.php
@@ -23,7 +23,6 @@ class CreateEmployeeLogTable extends Migration
             $table->text('objects');
             $table->datetime('audited_at');
             $table->string('ip_address')->nullable();
-            $table->boolean('is_dummy')->default(false);
             $table->timestamps();
             $table->foreign('employee_id')->references('id')->on('employees')->onDelete('cascade');
             $table->foreign('author_id')->references('id')->on('employees')->onDelete('set null');

--- a/database/migrations/2019_04_07_212958_create_positions_table.php
+++ b/database/migrations/2019_04_07_212958_create_positions_table.php
@@ -18,7 +18,6 @@ class CreatePositionsTable extends Migration
             $table->id();
             $table->unsignedBigInteger('company_id');
             $table->string('title');
-            $table->boolean('is_dummy')->default(false);
             $table->timestamps();
             $table->foreign('company_id')->references('id')->on('companies')->onDelete('cascade');
         });

--- a/database/migrations/2019_04_15_004856_create_team_log_table.php
+++ b/database/migrations/2019_04_15_004856_create_team_log_table.php
@@ -23,7 +23,6 @@ class CreateTeamLogTable extends Migration
             $table->text('objects');
             $table->datetime('audited_at');
             $table->string('ip_address')->nullable();
-            $table->boolean('is_dummy')->default(false);
             $table->timestamps();
             $table->foreign('team_id')->references('id')->on('teams')->onDelete('cascade');
             $table->foreign('author_id')->references('id')->on('employees')->onDelete('set null');

--- a/database/migrations/2019_04_25_000440_create_flows_table.php
+++ b/database/migrations/2019_04_25_000440_create_flows_table.php
@@ -19,7 +19,6 @@ class CreateFlowsTable extends Migration
             $table->unsignedBigInteger('company_id');
             $table->string('name');
             $table->string('type');
-            $table->boolean('is_dummy')->default(false);
             $table->timestamps();
             $table->foreign('company_id')->references('id')->on('companies')->onDelete('cascade');
         });

--- a/database/migrations/2019_04_27_142110_create_notifications_table.php
+++ b/database/migrations/2019_04_27_142110_create_notifications_table.php
@@ -20,7 +20,6 @@ class CreateNotificationsTable extends Migration
             $table->string('action');
             $table->text('objects');
             $table->boolean('read')->default(false);
-            $table->boolean('is_dummy')->default(false);
             $table->timestamps();
             $table->foreign('employee_id')->references('id')->on('employees')->onDelete('cascade');
         });

--- a/database/migrations/2019_04_27_151029_create_tasks_table.php
+++ b/database/migrations/2019_04_27_151029_create_tasks_table.php
@@ -21,7 +21,6 @@ class CreateTasksTable extends Migration
             $table->boolean('completed')->default(false);
             $table->datetime('due_at')->nullable();
             $table->datetime('completed_at')->nullable();
-            $table->boolean('is_dummy')->default(false);
             $table->timestamps();
             $table->foreign('employee_id')->references('id')->on('employees')->onDelete('cascade');
         });

--- a/database/migrations/2019_07_01_151704_create_worklog_table.php
+++ b/database/migrations/2019_07_01_151704_create_worklog_table.php
@@ -18,7 +18,6 @@ class CreateWorklogTable extends Migration
             $table->id();
             $table->unsignedBigInteger('employee_id')->nullable();
             $table->text('content');
-            $table->boolean('is_dummy')->default(false);
             $table->timestamps();
             $table->foreign('employee_id')->references('id')->on('employees')->onDelete('cascade');
         });

--- a/database/migrations/2019_08_02_114759_create_employee_statuses_table.php
+++ b/database/migrations/2019_08_02_114759_create_employee_statuses_table.php
@@ -18,7 +18,6 @@ class CreateEmployeeStatusesTable extends Migration
             $table->id();
             $table->unsignedBigInteger('company_id')->nullable();
             $table->string('name');
-            $table->boolean('is_dummy')->default(false);
             $table->timestamps();
             $table->foreign('company_id')->references('id')->on('companies')->onDelete('cascade');
         });

--- a/database/migrations/2019_08_24_042947_create_morale_table.php
+++ b/database/migrations/2019_08_24_042947_create_morale_table.php
@@ -19,7 +19,6 @@ class CreateMoraleTable extends Migration
             $table->unsignedBigInteger('employee_id');
             $table->integer('emotion');
             $table->string('comment')->nullable();
-            $table->boolean('is_dummy')->default(false);
             $table->timestamps();
             $table->foreign('employee_id')->references('id')->on('employees')->onDelete('cascade');
         });
@@ -29,7 +28,6 @@ class CreateMoraleTable extends Migration
             $table->unsignedBigInteger('company_id');
             $table->double('average');
             $table->integer('number_of_employees');
-            $table->boolean('is_dummy')->default(false);
             $table->timestamps();
             $table->foreign('company_id')->references('id')->on('companies')->onDelete('cascade');
         });
@@ -39,7 +37,6 @@ class CreateMoraleTable extends Migration
             $table->unsignedBigInteger('team_id');
             $table->double('average');
             $table->integer('number_of_team_members');
-            $table->boolean('is_dummy')->default(false);
             $table->timestamps();
             $table->foreign('team_id')->references('id')->on('teams')->onDelete('cascade');
         });

--- a/database/migrations/2019_08_25_112911_create_company_news_table.php
+++ b/database/migrations/2019_08_25_112911_create_company_news_table.php
@@ -21,7 +21,6 @@ class CreateCompanyNewsTable extends Migration
             $table->string('author_name');
             $table->string('title');
             $table->text('content');
-            $table->boolean('is_dummy')->default(false);
             $table->timestamps();
             $table->foreign('company_id')->references('id')->on('companies')->onDelete('cascade');
             $table->foreign('author_id')->references('id')->on('employees')->onDelete('set null');

--- a/database/migrations/2019_09_15_013403_create_places_table.php
+++ b/database/migrations/2019_09_15_013403_create_places_table.php
@@ -276,7 +276,6 @@ class CreatePlacesTable extends Migration
             $table->double('latitude')->nullable();
             $table->double('longitude')->nullable();
             $table->boolean('is_active')->default(false);
-            $table->boolean('is_dummy')->default(false);
             $table->timestamps();
             $table->foreign('country_id')->references('id')->on('countries')->onDelete('cascade');
         });

--- a/database/migrations/2019_09_23_013517_create_company_pto_policies.php
+++ b/database/migrations/2019_09_23_013517_create_company_pto_policies.php
@@ -22,7 +22,6 @@ class CreateCompanyPtoPolicies extends Migration
             $table->integer('default_amount_of_allowed_holidays')->nullable();
             $table->integer('default_amount_of_sick_days')->nullable();
             $table->integer('default_amount_of_pto_days')->nullable();
-            $table->boolean('is_dummy')->default(false);
             $table->timestamps();
             $table->foreign('company_id')->references('id')->on('companies')->onDelete('cascade');
         });

--- a/database/migrations/2019_09_26_010323_create_employee_pto_table.php
+++ b/database/migrations/2019_09_26_010323_create_employee_pto_table.php
@@ -21,7 +21,6 @@ class CreateEmployeePtoTable extends Migration
             $table->string('type');
             $table->boolean('full');
             $table->boolean('actually_taken')->default(false);
-            $table->boolean('is_dummy')->default(false);
             $table->timestamps();
             $table->foreign('employee_id')->references('id')->on('employees')->onDelete('cascade');
         });
@@ -34,7 +33,6 @@ class CreateEmployeePtoTable extends Migration
             $table->double('daily_accrued_amount');
             $table->double('current_holidays_per_year');
             $table->double('default_amount_of_allowed_holidays_in_company');
-            $table->boolean('is_dummy')->default(false);
             $table->timestamps();
             $table->foreign('employee_id')->references('id')->on('employees')->onDelete('cascade');
         });

--- a/database/migrations/2019_09_28_015610_create_company_calendar_table.php
+++ b/database/migrations/2019_09_28_015610_create_company_calendar_table.php
@@ -21,7 +21,6 @@ class CreateCompanyCalendarTable extends Migration
             $table->integer('day_of_week');
             $table->integer('day_of_year');
             $table->boolean('is_worked')->default(true);
-            $table->boolean('is_dummy')->default(false);
             $table->timestamps();
             $table->foreign('company_pto_policy_id')->references('id')->on('company_pto_policies')->onDelete('cascade');
         });

--- a/database/migrations/2019_12_07_023651_create_team_news_table.php
+++ b/database/migrations/2019_12_07_023651_create_team_news_table.php
@@ -21,7 +21,6 @@ class CreateTeamNewsTable extends Migration
             $table->string('author_name');
             $table->string('title');
             $table->text('content');
-            $table->boolean('is_dummy')->default(false);
             $table->timestamps();
             $table->foreign('team_id')->references('id')->on('teams')->onDelete('cascade');
             $table->foreign('author_id')->references('id')->on('employees')->onDelete('set null');

--- a/database/migrations/2020_04_03_234225_create_questions_table.php
+++ b/database/migrations/2020_04_03_234225_create_questions_table.php
@@ -21,7 +21,6 @@ class CreateQuestionsTable extends Migration
             $table->boolean('active')->default(false);
             $table->dateTime('activated_at')->nullable();
             $table->dateTime('deactivated_at')->nullable();
-            $table->boolean('is_dummy')->default(false);
             $table->timestamps();
             $table->foreign('company_id')->references('id')->on('companies')->onDelete('cascade');
         });

--- a/database/migrations/2020_04_18_163749_create_hardware_table.php
+++ b/database/migrations/2020_04_18_163749_create_hardware_table.php
@@ -20,7 +20,6 @@ class CreateHardwareTable extends Migration
             $table->unsignedBigInteger('employee_id')->nullable();
             $table->string('name');
             $table->string('serial_number')->nullable();
-            $table->boolean('is_dummy')->default(false);
             $table->timestamps();
             $table->foreign('company_id')->references('id')->on('companies')->onDelete('cascade');
             $table->foreign('employee_id')->references('id')->on('employees')->onDelete('set null');

--- a/database/migrations/2020_06_07_020824_create_ships_table.php
+++ b/database/migrations/2020_06_07_020824_create_ships_table.php
@@ -19,7 +19,6 @@ class CreateShipsTable extends Migration
             $table->unsignedBigInteger('team_id');
             $table->string('title');
             $table->text('description')->nullable();
-            $table->boolean('is_dummy')->default(false);
             $table->timestamps();
             $table->foreign('team_id')->references('id')->on('teams')->onDelete('cascade');
         });

--- a/database/migrations/2020_06_20_025159_create_specialty_table.php
+++ b/database/migrations/2020_06_20_025159_create_specialty_table.php
@@ -18,7 +18,6 @@ class CreateSpecialtyTable extends Migration
             $table->id();
             $table->unsignedBigInteger('company_id');
             $table->string('name');
-            $table->boolean('is_dummy')->default(false);
             $table->timestamps();
             $table->foreign('company_id')->references('id')->on('companies')->onDelete('cascade');
         });

--- a/tests/Unit/Services/Company/Employee/Morale/LogMoraleTest.php
+++ b/tests/Unit/Services/Company/Employee/Morale/LogMoraleTest.php
@@ -121,7 +121,6 @@ class LogMoraleTest extends TestCase
             'employee_id' => $dwight->id,
             'emotion' => 1,
             'comment' => 'Michael is my idol',
-            'is_dummy' => false,
         ]);
 
         $this->assertInstanceOf(


### PR DESCRIPTION
`is_dummy` was used to populate an account with fake data in the past.
But now that we populate an account through the command line, we don’t need to keep track of fake data alongside real data.
This PR removes that.