### PR TITLE
fix: fix one on one entries not being sorted by happened date

### DIFF
--- a/app/Services/Company/Employee/OneOnOne/CreateOneOnOneEntry.php
+++ b/app/Services/Company/Employee/OneOnOne/CreateOneOnOneEntry.php
@@ -103,7 +103,7 @@ class CreateOneOnOneEntry extends BaseService
         $entries = OneOnOneEntry::where('manager_id', $this->data['manager_id'])
             ->where('employee_id', $this->data['employee_id'])
             ->with('actionItems')
-            ->latest()
+            ->orderBy('happened_at', 'desc')
             ->take(2)
             ->get();
 


### PR DESCRIPTION
Marking an entry as `happened` creates a new one on one entry, with unchecked action items of current entry being transferred as talking points in the new entry.

However, the CreateOneOnOneEntry service fetched the previous entry based on the creation date, and not the date the one on one happened. This was a bug.