### PR TITLE
ci: stop running sonarcloud for dependabot branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,7 +115,7 @@ jobs:
     needs: tests
     runs-on: ubuntu-latest
     name: Sonarcloud
-    if: ! startsWith(github.ref, 'dependabot/')
+    if: ${{ ! startsWith(github.ref, 'dependabot/') }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,6 +115,7 @@ jobs:
     needs: tests
     runs-on: ubuntu-latest
     name: Sonarcloud
+    if: ! startsWith(github.ref, 'dependabot/')
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
You fool, don't forget these steps:

- [ ] Unit tests
- [ ] Tests with Cypress
- [ ] Documentation
- [ ] Dummy data
