### PR TITLE
fix: fix ball-pulse css removal

### DIFF
--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -2,9 +2,18 @@ let mix = require('laravel-mix');
 const path = require('path')
 require('laravel-mix-purgecss');
 
+let purgeCssOptions = {
+  enabled: true,
+  // List of regex of CSS class to not remove
+  whitelistPatterns: [/^ball-pulse/],
+  // List of regex of CSS class name whose child path CSS class will not be removed
+  //  ex: to exclude "jane" in "mary jane": add "mary")
+  whitelistPatternsChildren: []
+};
+
 mix.js('resources/js/app.js', 'public/js')
   .sass('resources/sass/app.scss', 'public/css')
-  .purgeCss()
+  .purgeCss(purgeCssOptions)
   .webpackConfig({
     output: { chunkFilename: 'js/[name].js?id=[chunkhash]' },
     resolve: {
@@ -18,4 +27,4 @@ mix.js('resources/js/app.js', 'public/js')
     plugins: ['@babel/plugin-syntax-dynamic-import'],
   })
   .version()
-  .sourceMaps();
+  .sourceMaps(false);


### PR DESCRIPTION
- Add ball-pulse css class name to purgecss' whitelist
- Also add 'false' parameter to sourcemap to not create them on production


You fool, don't forget these steps:

- [ ] Unit tests
- [ ] Tests with Cypress
- [ ] Documentation
- [ ] Dummy data
