### PR TITLE
ci: add a setup command

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web: vendor/bin/heroku-php-apache2 /public
 queue: php artisan queue:work --sleep=3 --tries=3
-release: php artisan migrate --force -vvv
+release: php artisan setup --force -vvv

--- a/app.json
+++ b/app.json
@@ -26,7 +26,7 @@
     }
   ],
   "scripts": {
-    "postdeploy": "php artisan migrate --force -vvv"
+    "postdeploy": "php artisan setup --force -vvv"
   },
   "env": {
     "APP_KEY": {

--- a/app/Console/Commands/Helpers/Command.php
+++ b/app/Console/Commands/Helpers/Command.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Console\Commands\Helpers;
+
+use RuntimeException;
+use Tests\Helpers\CommandCallerFake;
+
+class Command
+{
+    /**
+     * Switch to a fake executor for testing purpose.
+     *
+     * @return CommandCallerContract
+     */
+    public static function fake() : CommandCallerContract
+    {
+        static::setBackend($fake = app(CommandCallerFake::class));
+
+        return $fake;
+    }
+
+    /**
+     * The Command Executor.
+     *
+     * @var CommandCallerContract
+     */
+    private static $CommandCaller;
+
+    /**
+     * Get the current backend command.
+     *
+     * @return CommandCallerContract
+     */
+    private static function getBackend() : CommandCallerContract
+    {
+        if (is_null(static::$CommandCaller)) {
+            static::$CommandCaller = app(CommandCaller::class);
+        }
+
+        return static::$CommandCaller;
+    }
+
+    /**
+     * Set the current backend command.
+     *
+     * @param CommandCallerContract $executor
+     */
+    public static function setBackend(CommandCallerContract $executor) : void
+    {
+        static::$CommandCaller = $executor;
+    }
+
+    /**
+     * Handle dynamic, static calls to the object.
+     *
+     * @param  string  $method
+     * @param  array  $args
+     * @return mixed
+     *
+     * @throws \RuntimeException
+     */
+    public static function __callStatic($method, $args)
+    {
+        $instance = static::getBackend();
+
+        if (! $instance) {
+            throw new RuntimeException('No backend.');
+        }
+
+        return $instance->$method(...$args);
+    }
+}

--- a/app/Console/Commands/Helpers/Command.php
+++ b/app/Console/Commands/Helpers/Command.php
@@ -34,9 +34,7 @@ class Command
     private static function getBackend() : CommandCallerContract
     {
         if (is_null(static::$CommandCaller)) {
-            // @codeCoverageIgnoreStart
-            static::$CommandCaller = app(CommandCaller::class);
-            // @codeCoverageIgnoreEnd
+            static::$CommandCaller = app(CommandCaller::class); // @codeCoverageIgnore
         }
 
         return static::$CommandCaller;
@@ -66,9 +64,7 @@ class Command
         $instance = static::getBackend();
 
         if (! $instance) {
-            // @codeCoverageIgnoreStart
-            throw new RuntimeException('No backend.');
-            // @codeCoverageIgnoreEnd
+            throw new RuntimeException('No backend.'); // @codeCoverageIgnore
         }
 
         return $instance->$method(...$args);

--- a/app/Console/Commands/Helpers/Command.php
+++ b/app/Console/Commands/Helpers/Command.php
@@ -34,7 +34,9 @@ class Command
     private static function getBackend() : CommandCallerContract
     {
         if (is_null(static::$CommandCaller)) {
+            // @codeCoverageIgnoreStart
             static::$CommandCaller = app(CommandCaller::class);
+            // @codeCoverageIgnoreEnd
         }
 
         return static::$CommandCaller;
@@ -64,7 +66,9 @@ class Command
         $instance = static::getBackend();
 
         if (! $instance) {
+            // @codeCoverageIgnoreStart
             throw new RuntimeException('No backend.');
+            // @codeCoverageIgnoreEnd
         }
 
         return $instance->$method(...$args);

--- a/app/Console/Commands/Helpers/CommandCaller.php
+++ b/app/Console/Commands/Helpers/CommandCaller.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Console\Commands\Helpers;
+
+use Illuminate\Console\Command;
+use Illuminate\Console\Application;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class CommandCaller implements CommandCallerContract
+{
+    /**
+     * Print a message on the console, then execute a command.
+     *
+     * @param Command $command  Laravel command context
+     * @param string $message   Message to output
+     * @param string $commandline Command to execute
+     *
+     * @codeCoverageIgnore
+     */
+    public function exec(Command $command, string $message, string $commandline): void
+    {
+        $command->info($message);
+        $command->line($commandline, null, OutputInterface::VERBOSITY_VERBOSE);
+        exec($commandline.' 2>&1', $output);
+        foreach ($output as $line) {
+            $command->line($line, null, OutputInterface::VERBOSITY_VERY_VERBOSE);
+        }
+        $command->line('', null, OutputInterface::VERBOSITY_VERBOSE);
+    }
+
+    /**
+     * Print a message on the console, then execute an artisan command.
+     *
+     * @param Command $command  Laravel command context
+     * @param string $message   Message to output
+     * @param string $commandline Artisan command name to execute
+     * @param array $arguments    Optional arguments to pass to the artisan command
+     *
+     * @codeCoverageIgnore
+     */
+    public function artisan(Command $command, string $message, string $commandline, array $arguments = []): void
+    {
+        $info = '';
+        foreach ($arguments as $key => $value) {
+            if (is_string($key)) {
+                $info .= ' '.$key.'="'.$value.'"';
+            } else {
+                $info .= ' '.$value;
+            }
+        }
+        $this->exec($command, $message, Application::formatCommandString($commandline.$info));
+    }
+}

--- a/app/Console/Commands/Helpers/CommandCallerContract.php
+++ b/app/Console/Commands/Helpers/CommandCallerContract.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Console\Commands\Helpers;
+
+use Illuminate\Console\Command;
+
+interface CommandCallerContract
+{
+    /**
+     * Print a message on the console, then execute a command.
+     *
+     * @param Command $command  Laravel command context
+     * @param string $message   Message to output
+     * @param string $commandline Command to execute
+     */
+    public function exec(Command $command, string $message, string $commandline): void;
+
+    /**
+     * Print a message on the console, then execute an artisan command.
+     *
+     * @param Command $command  Laravel command context
+     * @param string $message   Message to output
+     * @param string $commandline Artisan command name to execute
+     * @param array $arguments    Optional arguments to pass to the artisan command
+     */
+    public function artisan(Command $command, string $message, string $commandline, array $arguments = []): void;
+}

--- a/app/Console/Commands/Setup.php
+++ b/app/Console/Commands/Setup.php
@@ -38,9 +38,11 @@ class Setup extends Command
             }
 
             if ($this->getLaravel()->environment() == 'production') {
+                // @codeCoverageIgnoreStart
                 $this->artisan('✓ Clear config cache', 'config:clear');
                 $this->artisan('✓ Resetting route cache', 'route:cache');
                 $this->artisan('✓ Resetting view cache', 'view:clear');
+                // @codeCoverageIgnoreEnd
             } else {
                 $this->artisan('✓ Clear config cache', 'config:clear');
                 $this->artisan('✓ Clear route cache', 'route:clear');
@@ -50,7 +52,9 @@ class Setup extends Command
             if ($this->option('skip-storage-link') !== true
                 && $this->getLaravel()->environment() != 'testing'
                 && ! file_exists(public_path('storage'))) {
+                // @codeCoverageIgnoreStart
                 $this->artisan('✓ Symlink the storage folder', 'storage:link');
+                // @codeCoverageIgnoreEnd
             }
 
             $this->artisan('✓ Performing migrations', 'migrate', ['--force']);
@@ -58,7 +62,9 @@ class Setup extends Command
             // Cache config
             if ($this->getLaravel()->environment() == 'production'
                 && (config('cache.default') != 'database' || Schema::hasTable(config('cache.stores.database.table')))) {
+                // @codeCoverageIgnoreStart
                 $this->artisan('✓ Cache configuraton', 'config:cache');
+                // @codeCoverageIgnoreEnd
             }
 
             $this->line('Officelife '.config('officelife.app_version').' is set up, enjoy.');

--- a/app/Console/Commands/Setup.php
+++ b/app/Console/Commands/Setup.php
@@ -66,38 +66,4 @@ class Setup extends Command
             $this->line('Officelife '.config('officelife.app_version').' is set up, enjoy.');
         }
     }
-
-    /**
-     * @codeCoverageIgnore
-     * @param mixed $message
-     * @param mixed $commandline
-     */
-    public function exec($message, $commandline)
-    {
-        $this->info($message);
-        $this->line($commandline, null, OutputInterface::VERBOSITY_VERBOSE);
-        exec($commandline.' 2>&1', $output);
-        foreach ($output as $line) {
-            $this->line($line, null, OutputInterface::VERBOSITY_VERY_VERBOSE);
-        }
-        $this->line('', null, OutputInterface::VERBOSITY_VERBOSE);
-    }
-
-    /**
-     * @codeCoverageIgnore
-     * @param mixed $message
-     * @param mixed $commandline
-     */
-    public function artisan($message, $commandline, array $arguments = [])
-    {
-        $info = '';
-        foreach ($arguments as $key => $value) {
-            if (is_string($key)) {
-                $info .= ' '.$key.'="'.$value.'"';
-            } else {
-                $info .= ' '.$value;
-            }
-        }
-        $this->exec($message, Application::formatCommandString($commandline.$info));
-    }
 }

--- a/app/Console/Commands/Setup.php
+++ b/app/Console/Commands/Setup.php
@@ -3,10 +3,8 @@
 namespace App\Console\Commands;
 
 use Illuminate\Console\Command;
-use Illuminate\Console\Application;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Console\ConfirmableTrait;
-use Symfony\Component\Console\Output\OutputInterface;
 
 class Setup extends Command
 {

--- a/app/Console/Commands/Setup.php
+++ b/app/Console/Commands/Setup.php
@@ -52,9 +52,7 @@ class Setup extends Command
             if ($this->option('skip-storage-link') !== true
                 && $this->getLaravel()->environment() != 'testing'
                 && ! file_exists(public_path('storage'))) {
-                // @codeCoverageIgnoreStart
-                $this->artisan('✓ Symlink the storage folder', 'storage:link');
-                // @codeCoverageIgnoreEnd
+                $this->artisan('✓ Symlink the storage folder', 'storage:link'); // @codeCoverageIgnore
             }
 
             $this->artisan('✓ Performing migrations', 'migrate', ['--force']);
@@ -62,9 +60,7 @@ class Setup extends Command
             // Cache config
             if ($this->getLaravel()->environment() == 'production'
                 && (config('cache.default') != 'database' || Schema::hasTable(config('cache.stores.database.table')))) {
-                // @codeCoverageIgnoreStart
-                $this->artisan('✓ Cache configuraton', 'config:cache');
-                // @codeCoverageIgnoreEnd
+                $this->artisan('✓ Cache configuraton', 'config:cache'); // @codeCoverageIgnore
             }
 
             $this->line('Officelife '.config('officelife.app_version').' is set up, enjoy.');

--- a/app/Console/Commands/Setup.php
+++ b/app/Console/Commands/Setup.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Console\Application;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Console\ConfirmableTrait;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Setup extends Command
+{
+    use ConfirmableTrait;
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'setup
+                            {--force : Force the operation to run when in production.}
+                            {--skip-storage-link : Skip storage link create.}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Install or update the application, and run migrations after a new release';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): void
+    {
+        if ($this->confirmToProceed()) {
+            // Clear or rebuild all cache
+            if (config('cache.default') != 'database' || Schema::hasTable(config('cache.stores.database.table'))) {
+                $this->artisan('✓ Resetting application cache', 'cache:clear');
+            }
+
+            if ($this->getLaravel()->environment() == 'production') {
+                $this->artisan('✓ Clear config cache', 'config:clear');
+                $this->artisan('✓ Resetting route cache', 'route:cache');
+                $this->artisan('✓ Resetting view cache', 'view:clear');
+            } else {
+                $this->artisan('✓ Clear config cache', 'config:clear');
+                $this->artisan('✓ Clear route cache', 'route:clear');
+                $this->artisan('✓ Clear view cache', 'view:clear');
+            }
+
+            if ($this->option('skip-storage-link') !== true
+                && $this->getLaravel()->environment() != 'testing'
+                && ! file_exists(public_path('storage'))) {
+                $this->artisan('✓ Symlink the storage folder', 'storage:link');
+            }
+
+            $this->artisan('✓ Performing migrations', 'migrate', ['--force']);
+
+            // Cache config
+            if ($this->getLaravel()->environment() == 'production'
+                && (config('cache.default') != 'database' || Schema::hasTable(config('cache.stores.database.table')))) {
+                $this->artisan('✓ Cache configuraton', 'config:cache');
+            }
+
+            $this->line('Officelife '.config('officelife.app_version').' is set up, enjoy.');
+        }
+    }
+
+    /**
+     * @codeCoverageIgnore
+     * @param mixed $message
+     * @param mixed $commandline
+     */
+    public function exec($message, $commandline)
+    {
+        $this->info($message);
+        $this->line($commandline, null, OutputInterface::VERBOSITY_VERBOSE);
+        exec($commandline.' 2>&1', $output);
+        foreach ($output as $line) {
+            $this->line($line, null, OutputInterface::VERBOSITY_VERY_VERBOSE);
+        }
+        $this->line('', null, OutputInterface::VERBOSITY_VERBOSE);
+    }
+
+    /**
+     * @codeCoverageIgnore
+     * @param mixed $message
+     * @param mixed $commandline
+     */
+    public function artisan($message, $commandline, array $arguments = [])
+    {
+        $info = '';
+        foreach ($arguments as $key => $value) {
+            if (is_string($key)) {
+                $info .= ' '.$key.'="'.$value.'"';
+            } else {
+                $info .= ' '.$value;
+            }
+        }
+        $this->exec($message, Application::formatCommandString($commandline.$info));
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -23,9 +23,7 @@ class AppServiceProvider extends ServiceProvider
 
         if (App::runningInConsole()) {
             Command::macro('exec', function(string $message, string $commandline) {
-                // @codeCoverageIgnoreStart
-                \App\Console\Commands\Helpers\Command::exec($this, $message, $commandline);
-                // @codeCoverageIgnoreEnd
+                \App\Console\Commands\Helpers\Command::exec($this, $message, $commandline); // @codeCoverageIgnore
             });
             Command::macro('artisan', function(string $message, string $commandline, array $arguments = []) {
                 \App\Console\Commands\Helpers\Command::artisan($this, $message, $commandline, $arguments);

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -23,6 +23,7 @@ class AppServiceProvider extends ServiceProvider
 
         if (App::runningInConsole()) {
             Command::macro('exec', function(string $message, string $commandline) {
+                /** @codeCoverageIgnore */
                 \App\Console\Commands\Helpers\Command::exec($this, $message, $commandline);
             });
             Command::macro('artisan', function(string $message, string $commandline, array $arguments = []) {

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,7 +4,9 @@ namespace App\Providers;
 
 use Inertia\Inertia;
 use App\Helpers\InstanceHelper;
+use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\Session;
 use Illuminate\Support\ServiceProvider;
@@ -18,6 +20,15 @@ class AppServiceProvider extends ServiceProvider
     {
         Schema::defaultStringLength(191);
         $this->registerInertia();
+
+        if (App::runningInConsole()) {
+            Command::macro('exec', function(string $message, string $commandline) {
+                \App\Console\Commands\Helpers\Command::exec($this, $message, $commandline);
+            });
+            Command::macro('artisan', function(string $message, string $commandline, array $arguments = []) {
+                \App\Console\Commands\Helpers\Command::artisan($this, $message, $commandline, $arguments);
+            });
+        }
     }
 
     /**

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -23,8 +23,9 @@ class AppServiceProvider extends ServiceProvider
 
         if (App::runningInConsole()) {
             Command::macro('exec', function(string $message, string $commandline) {
-                /** @codeCoverageIgnore */
+                // @codeCoverageIgnoreStart
                 \App\Console\Commands\Helpers\Command::exec($this, $message, $commandline);
+                // @codeCoverageIgnoreEnd
             });
             Command::macro('artisan', function(string $message, string $commandline, array $arguments = []) {
                 \App\Console\Commands\Helpers\Command::artisan($this, $message, $commandline, $arguments);

--- a/tests/Helpers/CommandCallerFake.php
+++ b/tests/Helpers/CommandCallerFake.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Helpers;
+
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Assert;
+use App\Console\Commands\Helpers\CommandCallerContract;
+
+class CommandCallerFake implements CommandCallerContract
+{
+    /**
+     * @var \Illuminate\Support\Collection
+     */
+    public $buffer;
+
+    /**
+     * Create a new CommandCallerTester.
+     */
+    public function __construct()
+    {
+        $this->buffer = collect([]);
+    }
+
+    public function exec($command, $message, $commandline): void
+    {
+        $this->buffer->push(['message' => $message, 'command' => $commandline]);
+    }
+
+    public function artisan($command, $message, $commandline, array $arguments = []): void
+    {
+        $info = '';
+        foreach ($arguments as $key => $value) {
+            $info = $info.' '.$key.'='.$value;
+        }
+        $this->buffer->push(['message' =>$message, 'command' => 'php artisan '.$commandline.$info]);
+    }
+
+    /**
+     * Assert the command identified by a message has been launched.
+     */
+    public function assertContainsMessage(string $message)
+    {
+        $messages = $this->buffer->map(function ($line) {
+            return $line['message'];
+        });
+        Assert::assertContains($message, $messages);
+    }
+}

--- a/tests/Unit/Commands/SetupCommandTest.php
+++ b/tests/Unit/Commands/SetupCommandTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Unit\Commands;
+
+use Tests\TestCase;
+use Illuminate\Support\Facades\Artisan;
+use App\Console\Commands\Helpers\Command;
+
+class SetupCommandTest extends TestCase
+{
+    /** @test */
+    public function it_run_setup_command(): void
+    {
+        /** @var \Tests\Helpers\CommandCallerFake */
+        $fake = Command::fake();
+
+        Artisan::call('setup');
+
+        $this->assertCount(5, $fake->buffer);
+        $fake->assertContainsMessage('✓ Resetting application cache');
+        $fake->assertContainsMessage('✓ Clear config cache');
+        $fake->assertContainsMessage('✓ Clear route cache');
+        $fake->assertContainsMessage('✓ Clear view cache');
+        $fake->assertContainsMessage('✓ Performing migrations');
+    }
+}


### PR DESCRIPTION
This adds a new command called 'setup' to run all needed operations to install or update the application.
- config clear/cache
- cache clear
- view clear/cache
- route clear/cache
- migration


You fool, don't forget these steps:

- [x] Unit tests
- [ ] Tests with Cypress
- [ ] Documentation
- [ ] Dummy data
