### PR TITLE
chore: put back DS_store in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ Homestead.json
 Homestead.yaml
 npm-debug.log
 yarn-error.log
+.DS_Store


### PR DESCRIPTION
We need to keep `.DS_store` in gitignore (which @asbiin you removed last week) because it’s added everywhere on macOS and will be a constant pain for all devs that might contribute to the project. It’s better to put it back.