### PR TITLE
feat: add an option to disable mail verification

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -45,7 +45,7 @@ class RegisterController extends Controller
             'password',
         ]));
 
-        if (User::count() == 1) {
+        if (! config('mail.verify') || User::count() == 1) {
             // if it's the first user, we can skip the email verification
             $user->markEmailAsVerified();
         } else {

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -61,7 +61,7 @@ class Kernel extends HttpKernel
         'password.confirm' => \Illuminate\Auth\Middleware\RequirePassword::class,
         'signed' => \Illuminate\Routing\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
-        'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
+        'verified' => \App\Http\Middleware\EnsureEmailIsVerified::class,
         'company' => \App\Http\Middleware\CheckCompany::class,
         'administrator' => \App\Http\Middleware\CheckAdministratorRole::class,
         'hr' => \App\Http\Middleware\CheckHRRole::class,

--- a/app/Http/Middleware/EnsureEmailIsVerified.php
+++ b/app/Http/Middleware/EnsureEmailIsVerified.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Auth\Middleware\EnsureEmailIsVerified as Middleware;
+
+class EnsureEmailIsVerified extends Middleware
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @param mixed|null $redirectToRoute
+     * @return \Illuminate\Http\RedirectResponse|\Illuminate\Http\Response
+     */
+    public function handle($request, Closure $next, $redirectToRoute = null)
+    {
+        if (config('mail.verify')) {
+            return parent::handle($request, $next, $redirectToRoute);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Models/User/User.php
+++ b/app/Models/User/User.php
@@ -150,7 +150,7 @@ class User extends Authenticatable implements MustVerifyEmail
      */
     public function sendEmailVerificationNotification(): void
     {
-        if (User::count() > 1) {
+        if (config('mail.verify') && User::count() > 1) {
             SendVerifyEmail::dispatch($this);
         }
     }

--- a/config/mail.php
+++ b/config/mail.php
@@ -107,4 +107,15 @@ return [
         ],
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Verify Email
+    |--------------------------------------------------------------------------
+    |
+    | Verifies the user's email by sending a verification mail.
+    |
+    */
+
+    'verify' => (bool) env('MAIL_VERIFY', true),
+
 ];


### PR DESCRIPTION
This adds a new `MAIL_VERIFY` environment variable to disable email verification (true by default = enabled).
Cypress tests will require MAIL_VERIFY=false

You fool, don't forget these steps:

- [ ] Unit tests
- [ ] Tests with Cypress
- [ ] Documentation
- [ ] Dummy data
