### PR TITLE
refactor: simpler navigation

### DIFF
--- a/resources/js/Pages/Dashboard/Expenses/Index.vue
+++ b/resources/js/Pages/Dashboard/Expenses/Index.vue
@@ -44,12 +44,6 @@
 <template>
   <layout title="Home" :notifications="notifications">
     <div class="ph2 ph0-ns">
-      <div class="cf mt4 mw7 center">
-        <h2 class="tc fw5">
-          {{ $page.props.auth.company.name }}
-        </h2>
-      </div>
-
       <dashboard-menu :employee="employee" />
 
       <!-- LIST OF EXPENSES THAT ARE AWAITING FOR ACCOUNTING VALIDATION -->

--- a/resources/js/Pages/Dashboard/Manager/Index.vue
+++ b/resources/js/Pages/Dashboard/Manager/Index.vue
@@ -8,12 +8,6 @@
 <template>
   <layout title="Home" :notifications="notifications">
     <div class="ph2 ph0-ns">
-      <div class="cf mt4 mw7 center">
-        <h2 class="tc fw5">
-          {{ $page.props.auth.company.name }}
-        </h2>
-      </div>
-
       <dashboard-menu :employee="employee" />
     </div>
 

--- a/resources/js/Pages/Dashboard/Me/Index.vue
+++ b/resources/js/Pages/Dashboard/Me/Index.vue
@@ -8,12 +8,6 @@
 <template>
   <layout title="Home" :notifications="notifications">
     <div class="ph2 ph0-ns">
-      <div class="cf mt4 mw7 center">
-        <h2 class="tc fw5">
-          {{ $page.props.auth.company.name }}
-        </h2>
-      </div>
-
       <dashboard-menu :employee="employee" />
 
       <one-on-one-with-manager

--- a/resources/js/Pages/Dashboard/Partials/DashboardMenu.vue
+++ b/resources/js/Pages/Dashboard/Partials/DashboardMenu.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="cf mw7 center br3 mb5 tc">
+  <div class="cf mw7 center br3 mt5 mb5 tc">
     <div class="cf dib btn-group">
       <inertia-link :href="'/' + $page.props.auth.company.id + '/dashboard/me'" class="f6 fl ph3 pv2 dib pointer no-underline" :class="{'selected':(employee.dashboard_view == 'me')}">
         {{ $t('dashboard.tab_me') }}

--- a/resources/js/Pages/Dashboard/Team/Index.vue
+++ b/resources/js/Pages/Dashboard/Team/Index.vue
@@ -17,12 +17,6 @@
 <template>
   <layout title="Home" :notifications="notifications">
     <div class="ph2 ph0-ns">
-      <div class="cf mt4 mw7 center">
-        <h2 class="tc fw5">
-          {{ company.name }}
-        </h2>
-      </div>
-
       <dashboard-menu :employee="employee" />
 
       <div v-show="teams.length > 1" class="cf mw7 center mb3">

--- a/resources/js/Shared/Layout.vue
+++ b/resources/js/Shared/Layout.vue
@@ -61,20 +61,11 @@ nav {
             <inertia-link v-if="$page.props.auth.employee.display_welcome_message" :href="'/' + $page.props.auth.company.id + '/welcome'" data-cy="header-desktop-welcome-tab" class="mr1 no-underline pa2 bb-0 special">
               <span class="mr1">👋</span> {{ $t('app.header_welcome') }}
             </inertia-link>
-            <inertia-link :href="'/' + $page.props.auth.company.id + '/company'" class="mr1 no-underline pa2 bb-0 special" data-cy="header-teams-link">
-              <span class="mr1">⛺️</span> {{ $t('app.header_company') }}
-            </inertia-link>
-            <inertia-link :href="'/' + $page.props.auth.company.id + '/projects'" class="mr1 no-underline pa2 bb-0 special" data-cy="header-teams-link">
-              <span class="mr1">👨‍🚀</span> Projects
-            </inertia-link>
             <inertia-link :href="'/' + $page.props.auth.company.id + '/dashboard'" class="mr1 no-underline pa2 bb-0 special">
               <span class="mr1">🏡</span> {{ $t('app.header_home') }}
             </inertia-link>
-            <inertia-link :href="'/' + $page.props.auth.company.id + '/employees'" class="mr1 no-underline pa2 bb-0 special">
-              <span class="mr1">🧑</span> {{ $t('app.header_employees') }}
-            </inertia-link>
-            <inertia-link :href="'/' + $page.props.auth.company.id + '/teams'" class="mr1 no-underline pa2 bb-0 special" data-cy="header-teams-link">
-              <span class="mr1">👫</span> {{ $t('app.header_teams') }}
+            <inertia-link :href="'/' + $page.props.auth.company.id + '/company'" class="mr1 no-underline pa2 bb-0 special" data-cy="header-teams-link">
+              <span class="mr1">⛺️</span> {{ $t('app.header_company') }}
             </inertia-link>
             <a data-cy="header-find-link" class="mr1 no-underline pa2 bb-0 special pointer" @click="showFindModal">
               <span class="mr1">🔍</span> {{ $t('app.header_find') }}

--- a/resources/lang/en/app.php
+++ b/resources/lang/en/app.php
@@ -119,8 +119,6 @@ return [
     'header_welcome' => 'Welcome',
     'header_home' => 'Home',
     'header_find' => 'Find',
-    'header_employees' => 'Employees',
-    'header_teams' => 'Teams',
     'header_company' => 'Company',
     'header_switch_company' => 'Switch company',
     'header_go_to_employee_profile' => 'Your profile',


### PR DESCRIPTION
In the coming weeks I'll simplify the navigation.

I've started here to remove elements that won't be that used in the header of the app, like Teams or Employees. Those two options will be found later on in the Company tab.

<img width="1252" alt="Screen Shot 2020-12-12 at 20 53 03" src="https://user-images.githubusercontent.com/61099/102001118-44c1c580-3cbc-11eb-9c5f-cb801317f864.png">
