### PR TITLE
feat: load employee statuses on demand

### DIFF
--- a/app/Http/Controllers/Company/Employee/EmployeeController.php
+++ b/app/Http/Controllers/Company/Employee/EmployeeController.php
@@ -13,7 +13,6 @@ use App\Helpers\NotificationHelper;
 use App\Http\Controllers\Controller;
 use App\Http\Collections\PronounCollection;
 use App\Http\Collections\PositionCollection;
-use App\Http\Collections\EmployeeStatusCollection;
 use App\Services\Company\Employee\Manager\AssignManager;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use App\Http\ViewHelpers\Employee\EmployeeShowViewHelper;
@@ -154,7 +153,6 @@ class EmployeeController extends Controller
             'employeeTeams' => $employeeTeams,
             'positions' => PositionCollection::prepare($company->positions()->get()),
             'teams' => $teams,
-            'statuses' => EmployeeStatusCollection::prepare($company->employeeStatuses()->get()),
             'pronouns' => PronounCollection::prepare(Pronoun::all()),
             'ships' => $ships,
             'skills' => $skills,

--- a/app/Http/Controllers/Company/Employee/EmployeePerformanceController.php
+++ b/app/Http/Controllers/Company/Employee/EmployeePerformanceController.php
@@ -12,7 +12,6 @@ use App\Helpers\NotificationHelper;
 use App\Http\Controllers\Controller;
 use App\Http\Collections\PronounCollection;
 use App\Http\Collections\PositionCollection;
-use App\Http\Collections\EmployeeStatusCollection;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use App\Http\ViewHelpers\Employee\EmployeeShowViewHelper;
 use App\Http\ViewHelpers\Employee\EmployeePerformanceViewHelper;
@@ -77,7 +76,6 @@ class EmployeePerformanceController extends Controller
             'employeeTeams' => $employeeTeams,
             'positions' => PositionCollection::prepare($company->positions()->get()),
             'teams' => $teams,
-            'statuses' => EmployeeStatusCollection::prepare($company->employeeStatuses()->get()),
             'pronouns' => PronounCollection::prepare(Pronoun::all()),
             'surveys' => $surveys,
         ]);

--- a/app/Http/Controllers/Company/Employee/EmployeeStatusController.php
+++ b/app/Http/Controllers/Company/Employee/EmployeeStatusController.php
@@ -8,11 +8,31 @@ use App\Helpers\InstanceHelper;
 use App\Models\Company\Employee;
 use Illuminate\Http\JsonResponse;
 use App\Http\Controllers\Controller;
+use App\Http\ViewHelpers\Employee\EmployeeShowViewHelper;
 use App\Services\Company\Employee\EmployeeStatus\AssignEmployeeStatusToEmployee;
 use App\Services\Company\Employee\EmployeeStatus\RemoveEmployeeStatusFromEmployee;
 
 class EmployeeStatusController extends Controller
 {
+    /**
+     * Return the list of employee statuses in the company.
+     *
+     * @param Request $request
+     * @param int $companyId
+     * @param int $employeeId
+     * @return JsonResponse
+     */
+    public function index(Request $request, int $companyId, int $employeeId): JsonResponse
+    {
+        $loggedCompany = InstanceHelper::getLoggedCompany();
+
+        $statuses = EmployeeShowViewHelper::employeeStatuses($loggedCompany);
+
+        return response()->json([
+            'data' => $statuses,
+        ], 200);
+    }
+
     /**
      * Assign an employee status to the given employee.
      *

--- a/app/Http/Middleware/CheckCompany.php
+++ b/app/Http/Middleware/CheckCompany.php
@@ -28,16 +28,15 @@ class CheckCompany
                 ->where('company_id', $requestedCompanyId)
                 ->firstOrFail();
 
-                if ($employee->locked) {
-                    abort(401);
-                }
+            if ($employee->locked) {
+                abort(401);
+            }
 
-                $cachedCompanyObject = 'cachedCompanyObject_' . Auth::user()->id;
-                $cachedEmployeeObject = 'cachedEmployeeObject_' . Auth::user()->id;
+            $cachedCompanyObject = 'cachedCompanyObject_' . Auth::user()->id;
+            $cachedEmployeeObject = 'cachedEmployeeObject_' . Auth::user()->id;
 
-                Cache::put($cachedCompanyObject, $employee->company, now()->addMinutes(60));
-                Cache::put($cachedEmployeeObject, $employee, now()->addMinutes(60));
-
+            Cache::put($cachedCompanyObject, $employee->company, now()->addMinutes(60));
+            Cache::put($cachedEmployeeObject, $employee, now()->addMinutes(60));
         } catch (ModelNotFoundException $e) {
             abort(401);
         }

--- a/app/Http/ViewHelpers/Employee/EmployeeShowViewHelper.php
+++ b/app/Http/ViewHelpers/Employee/EmployeeShowViewHelper.php
@@ -7,6 +7,7 @@ use App\Helpers\DateHelper;
 use App\Helpers\MoneyHelper;
 use App\Helpers\StringHelper;
 use App\Helpers\WorklogHelper;
+use App\Models\Company\Company;
 use App\Models\Company\Employee;
 use Illuminate\Support\Collection;
 use App\Helpers\WorkFromHomeHelper;
@@ -624,5 +625,26 @@ class EmployeeShowViewHelper
                 'employee' => $employee,
             ]),
         ];
+    }
+
+    /**
+     * Get the employee statuses for the given company.
+     *
+     * @param Company $company
+     * @return Collection
+     */
+    public static function employeeStatuses(Company $company): Collection
+    {
+        $statuses = $company->employeeStatuses()->get();
+
+        $statusCollection = collect([]);
+        foreach ($statuses as $status) {
+            $statusCollection->push([
+                'id' => $status->id,
+                'name' => $status->name,
+            ]);
+        }
+
+        return $statusCollection;
     }
 }

--- a/resources/js/Pages/Employee/Partials/EmployeeStatus.vue
+++ b/resources/js/Pages/Employee/Partials/EmployeeStatus.vue
@@ -26,7 +26,7 @@
       <li class="di" data-cy="status-name-right-permission">
         {{ updatedEmployee.status.name }}
       </li>
-      <li data-cy="open-status-modal" class="bb b--dotted bt-0 bl-0 br-0 pointer di" @click.prevent="modal = true">
+      <li data-cy="open-status-modal" class="bb b--dotted bt-0 bl-0 br-0 pointer di" @click.prevent="displayModal()">
         {{ $t('app.edit') }}
       </li>
     </ul>
@@ -37,7 +37,7 @@
     </ul>
 
     <!-- Action when there is no status defined -->
-    <a v-show="!updatedEmployee.status" v-if="permissions.can_manage_status" class="bb b--dotted bt-0 bl-0 br-0 pointer" data-cy="open-status-modal-blank" @click.prevent="modal = true">
+    <a v-show="!updatedEmployee.status" v-if="permissions.can_manage_status" class="bb b--dotted bt-0 bl-0 br-0 pointer" data-cy="open-status-modal-blank" @click.prevent="displayModal()">
       {{ $t('employee.status_modal_cta') }}
     </a>
     <span v-else v-show="!updatedEmployee.status">
@@ -109,10 +109,6 @@ export default {
       type: Object,
       default: null,
     },
-    statuses: {
-      type: Array,
-      default: null,
-    },
     permissions: {
       type: Object,
       default: null,
@@ -121,6 +117,7 @@ export default {
 
   data() {
     return {
+      statuses: null,
       modal: false,
       search: '',
       updatedEmployee: Object,
@@ -144,8 +141,25 @@ export default {
   },
 
   methods: {
+    displayModal() {
+      this.load();
+      this.modal = true;
+    },
+
     toggleModal() {
       this.modal = false;
+    },
+
+    load() {
+      if (! this.statuses) {
+        axios.get('/' + this.$page.props.auth.company.id + '/employees/' + this.employee.id + '/employeestatuses')
+          .then(response => {
+            this.statuses = response.data.data;
+          })
+          .catch(error => {
+            this.form.errors = error.response.data;
+          });
+      }
     },
 
     assign(status) {

--- a/resources/js/Pages/Employee/Partials/HeaderEmployee.vue
+++ b/resources/js/Pages/Employee/Partials/HeaderEmployee.vue
@@ -135,7 +135,6 @@
                 <span class="f7 gray">{{ $t('employee.status_title') }}</span>
                 <employee-status
                   :employee="employee"
-                  :statuses="statuses"
                   :permissions="permissions"
                 />
               </p>
@@ -224,10 +223,6 @@ export default {
       default: null,
     },
     teams: {
-      type: Array,
-      default: null,
-    },
-    statuses: {
       type: Array,
       default: null,
     },

--- a/resources/js/Pages/Employee/Performance/Index.vue
+++ b/resources/js/Pages/Employee/Performance/Index.vue
@@ -25,7 +25,6 @@
         :employee-teams="employeeTeams"
         :positions="positions"
         :teams="teams"
-        :statuses="statuses"
         :pronouns="pronouns"
       />
 
@@ -102,10 +101,6 @@ export default {
       default: null,
     },
     teams: {
-      type: Array,
-      default: null,
-    },
-    statuses: {
       type: Array,
       default: null,
     },

--- a/resources/js/Pages/Employee/Show.vue
+++ b/resources/js/Pages/Employee/Show.vue
@@ -25,7 +25,6 @@
         :employee-teams="employeeTeams"
         :positions="positions"
         :teams="teams"
-        :statuses="statuses"
         :pronouns="pronouns"
       />
 
@@ -194,10 +193,6 @@ export default {
     },
     worklogs: {
       type: Object,
-      default: null,
-    },
-    statuses: {
-      type: Array,
       default: null,
     },
     pronouns: {

--- a/routes/web.php
+++ b/routes/web.php
@@ -130,7 +130,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
             ]);
 
             Route::resource('{employee}/employeestatuses', 'Company\\Employee\\EmployeeStatusController')->only([
-                'store', 'destroy',
+                'index', 'store', 'destroy',
             ]);
 
             Route::resource('{employee}/pronoun', 'Company\\Employee\\EmployeePronounController')->only([

--- a/tests/Unit/ViewHelpers/Employee/EmployeeShowViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Employee/EmployeeShowViewHelperTest.php
@@ -15,6 +15,7 @@ use App\Models\Company\Hardware;
 use App\Models\Company\Question;
 use App\Models\Company\WorkFromHome;
 use App\Models\Company\OneOnOneEntry;
+use App\Models\Company\EmployeeStatus;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use App\Services\Company\Employee\Manager\AssignManager;
 use App\Http\ViewHelpers\Employee\EmployeeShowViewHelper;
@@ -547,5 +548,27 @@ class EmployeeShowViewHelperTest extends TestCase
 
         $array = EmployeeShowViewHelper::oneOnOnes($dwight, ['can_see_one_on_one_with_manager' => false]);
         $this->assertNull($array);
+    }
+
+    /** @test */
+    public function it_gets_a_collection_of_employee_statuses(): void
+    {
+        $michael = $this->createAdministrator();
+
+        $collection = EmployeeShowViewHelper::employeeStatuses($michael->company);
+
+        $this->assertEquals(1, $collection->count());
+
+        $status = EmployeeStatus::first();
+
+        $this->assertEquals(
+            [
+                0 => [
+                    'id' => $status->id,
+                    'name' => $status->name,
+                ],
+            ],
+            $collection->toArray()
+        );
     }
 }


### PR DESCRIPTION
The employee statuses, on the employee profile page, have some problems.

1. The query to fetch them is done all the time, even if the employee can’t change statuses.
2. They use a previous concept of "collections" that I implemented two years ago, but it’s a really bad idea as a concept, for a lot of reasons.

In #436, I’m changing how employee statuses work under the hood, and I need the improvements I've done in this PR for this.

I wanted to split the work in smaller PR so #436 is not too big.

In short, this PR
* loads employee statuses on demand on the Employee profile page
* is the first step to enable the removal of the EmployeeStatusCollection method.

Note: ideally, all the data in the header of an Employee profile page should be loaded asynchronously, but we have to do it slowly, one by one, and proceed carefully.