### PR TITLE
fix: fix email verification in cypress

### DIFF
--- a/app/Console/Commands/Tests/VerifyEmailOfLastCreatedEmployee.php
+++ b/app/Console/Commands/Tests/VerifyEmailOfLastCreatedEmployee.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Console\Commands\Tests;
+
+use App\Models\User\User;
+use Illuminate\Console\Command;
+
+class VerifyEmailOfLastCreatedEmployee extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'setup:verify-email';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Verify the email of the last created employee during a Cypress test.';
+
+    /**
+     * Create a new command.
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): void
+    {
+        $user = User::latest()->first();
+        $user->email_verified_at = now();
+        $user->save();
+    }
+}

--- a/tests/Features/support/helpers/app.js
+++ b/tests/Features/support/helpers/app.js
@@ -120,9 +120,13 @@ Cypress.Commands.add('acceptInvitationLinkAndGoToDashboard', (password, link) =>
   cy.logout();
   cy.visit('/invite/employee/' + link);
   cy.get('[data-cy=accept-create-account]').click();
+
   cy.get('input[name=password]').type(password);
   cy.get('[data-cy=create-cta]').click();
-  cy.get('[data-cy=company-1]').click();
+  cy.exec('php artisan setup:verify-email').then((result) => {
+    cy.visit('/home');
+    cy.get('[data-cy=company-1]').click();
+  });
 });
 
 // Assert that the page can be visited by a user with the right permission level

--- a/tests/Integration/VerifyEmailOfLastCreatedEmployeeTest.php
+++ b/tests/Integration/VerifyEmailOfLastCreatedEmployeeTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\Integration;
+
+use Tests\TestCase;
+use App\Models\User\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+class VerifyEmailOfLastCreatedEmployeeTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    /** @test */
+    public function it_marks_the_last_created_employee_as_verified(): void
+    {
+        User::factory()->create();
+
+        $this->artisan('setup:verify-email');
+
+        $this->assertNotNull(User::latest()->first()->email_verified_at);
+    }
+}


### PR DESCRIPTION
Putting in place the email verification broke many Cypress tests, because now when we switch accounts to checks specific flows in Cypress, we are stuck in the Please verify email accounts page.

This PR tries to fix that by creating a new command that indicates an account has been verified already.

It’s a bit of a hack, but it works.

cc @asbiin