### PR TITLE
feat: HR dashboard for timesheets

### DIFF
--- a/app/Helpers/TimeHelper.php
+++ b/app/Helpers/TimeHelper.php
@@ -36,7 +36,7 @@ class TimeHelper
      * Gets a sentence representing the time given in the array.
      *
      * @param array $duration
-     * @return array
+     * @return string
      */
     public static function durationInHumanFormat(array $duration): string
     {

--- a/app/Helpers/TimeHelper.php
+++ b/app/Helpers/TimeHelper.php
@@ -35,7 +35,7 @@ class TimeHelper
     /**
      * Gets a sentence representing the time given in the array.
      *
-     * @param int $minutes
+     * @param array $duration
      * @return array
      */
     public static function durationInHumanFormat(array $duration): string

--- a/app/Helpers/TimeHelper.php
+++ b/app/Helpers/TimeHelper.php
@@ -12,7 +12,7 @@ class TimeHelper
      */
     public static function convertToHoursAndMinutes(int $minutes = null): array
     {
-        if (! $minutes) {
+        if (! $minutes || $minutes == 0) {
             return [
                 'hours' => 0,
                 'minutes' => 0,
@@ -30,5 +30,25 @@ class TimeHelper
             'hours' => $hours,
             'minutes' => $minutes,
         ];
+    }
+
+    /**
+     * Gets a sentence representing the time given in the array.
+     *
+     * @param int $minutes
+     * @return array
+     */
+    public static function durationInHumanFormat(array $duration): string
+    {
+        $minutes = $duration['minutes'] == 0 ? '00' : $duration['minutes'];
+
+        $time = trans('app.duration', [
+            'hours' => $duration['hours'],
+            'minutes' => $minutes,
+        ]);
+
+        $time = str_replace(' ', '', $time);
+
+        return $time;
     }
 }

--- a/app/Http/Controllers/Company/Dashboard/DashboardExpensesController.php
+++ b/app/Http/Controllers/Company/Dashboard/DashboardExpensesController.php
@@ -39,6 +39,7 @@ class DashboardExpensesController extends Controller
             'dashboard_view' => 'expenses',
             'is_manager' => $employee->directReports->count() > 0,
             'can_manage_expenses' => $employee->can_manage_expenses,
+            'can_manage_hr' => $employee->permission_level <= config('officelife.permission_level.hr'),
         ];
 
         return Inertia::render('Dashboard/Expenses/Index', [

--- a/app/Http/Controllers/Company/Dashboard/DashboardHRController.php
+++ b/app/Http/Controllers/Company/Dashboard/DashboardHRController.php
@@ -2,18 +2,54 @@
 
 namespace App\Http\Controllers\Company\Dashboard;
 
+use Inertia\Inertia;
 use Illuminate\Http\Request;
+use App\Helpers\InstanceHelper;
 use App\Models\Company\Company;
+use App\Helpers\NotificationHelper;
 use App\Http\Controllers\Controller;
+use App\Jobs\UpdateDashboardPreference;
+use App\Http\ViewHelpers\Dashboard\DashboardHRViewHelper;
 
 class DashboardHRController extends Controller
 {
     /**
      * Company details.
      *
-     * @param Request $request
+     * @return mixed
      */
-    public function index(Request $request): void
+    public function index(Request $request)
     {
+        $company = InstanceHelper::getLoggedCompany();
+        $employee = InstanceHelper::getLoggedEmployee();
+
+        // is this person HR?
+        if ($employee->permission_level > config('officelife.permission_level.hr')) {
+            return redirect('home');
+        }
+
+        UpdateDashboardPreference::dispatch([
+            'employee_id' => $employee->id,
+            'company_id' => $company->id,
+            'view' => 'hr',
+        ])->onQueue('low');
+
+        $employeeInformation = [
+            'id' => $employee->id,
+            'dashboard_view' => 'manager',
+            'is_manager' => true,
+            'can_manage_expenses' => $employee->can_manage_expenses,
+            'can_manage_hr' => $employee->permission_level <= config('officelife.permission_level.hr'),
+        ];
+
+        $employeesWithoutManagersWithPendingTimesheets = DashboardHRViewHelper::employeesWithoutManagersWithPendingTimesheets($company);
+        $statistics = DashboardHRViewHelper::statisticsAboutTimesheets($company);
+
+        return Inertia::render('Dashboard/HR/Index', [
+            'employee' => $employeeInformation,
+            'notifications' => NotificationHelper::getNotifications($employee),
+            'employeesWithPendingTimesheets' => $employeesWithoutManagersWithPendingTimesheets,
+            'statistics' => $statistics,
+        ]);
     }
 }

--- a/app/Http/Controllers/Company/Dashboard/DashboardHRController.php
+++ b/app/Http/Controllers/Company/Dashboard/DashboardHRController.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers\Company\Dashboard;
 use Inertia\Inertia;
 use Illuminate\Http\Request;
 use App\Helpers\InstanceHelper;
-use App\Models\Company\Company;
 use App\Helpers\NotificationHelper;
 use App\Http\Controllers\Controller;
 use App\Jobs\UpdateDashboardPreference;
@@ -14,7 +13,7 @@ use App\Http\ViewHelpers\Dashboard\DashboardHRViewHelper;
 class DashboardHRController extends Controller
 {
     /**
-     * Company details.
+     * Index of the HR tab on the dashboard.
      *
      * @return mixed
      */
@@ -36,20 +35,20 @@ class DashboardHRController extends Controller
 
         $employeeInformation = [
             'id' => $employee->id,
-            'dashboard_view' => 'manager',
+            'dashboard_view' => 'hr',
             'is_manager' => true,
             'can_manage_expenses' => $employee->can_manage_expenses,
             'can_manage_hr' => $employee->permission_level <= config('officelife.permission_level.hr'),
         ];
 
         $employeesWithoutManagersWithPendingTimesheets = DashboardHRViewHelper::employeesWithoutManagersWithPendingTimesheets($company);
-        $statistics = DashboardHRViewHelper::statisticsAboutTimesheets($company);
+        $statisticsAboutTimesheets = DashboardHRViewHelper::statisticsAboutTimesheets($company);
 
         return Inertia::render('Dashboard/HR/Index', [
             'employee' => $employeeInformation,
             'notifications' => NotificationHelper::getNotifications($employee),
-            'employeesWithPendingTimesheets' => $employeesWithoutManagersWithPendingTimesheets,
-            'statistics' => $statistics,
+            'employeesWithoutManagersWithPendingTimesheets' => $employeesWithoutManagersWithPendingTimesheets,
+            'statisticsAboutTimesheets' => $statisticsAboutTimesheets,
         ]);
     }
 }

--- a/app/Http/Controllers/Company/Dashboard/DashboardHRTimesheetController.php
+++ b/app/Http/Controllers/Company/Dashboard/DashboardHRTimesheetController.php
@@ -51,7 +51,7 @@ class DashboardHRTimesheetController extends Controller
      *
      * @param Request $request
      * @param int $companyId
-     * @param int $expenseId
+     * @param int $timesheetId
      *
      * @return \Illuminate\Http\RedirectResponse|\Illuminate\Routing\Redirector|Response
      */

--- a/app/Http/Controllers/Company/Dashboard/DashboardManagerController.php
+++ b/app/Http/Controllers/Company/Dashboard/DashboardManagerController.php
@@ -63,7 +63,7 @@ class DashboardManagerController extends Controller
         $pendingExpenses = DashboardManagerViewHelper::pendingExpenses($employee, $directReports);
         $oneOnOnes = DashboardManagerViewHelper::oneOnOnes($employee, $directReports);
         $contractRenewals = DashboardManagerViewHelper::contractRenewals($employee, $directReports);
-        $timesheetApprovals = DashboardManagerViewHelper::timesheetApprovals($employee, $directReports);
+        $timesheetsStats = DashboardManagerViewHelper::employeesWithTimesheetsToApprove($employee, $directReports);
 
         return Inertia::render('Dashboard/Manager/Index', [
             'employee' => $employeeInformation,
@@ -71,7 +71,7 @@ class DashboardManagerController extends Controller
             'pendingExpenses' => $pendingExpenses,
             'oneOnOnes' => $oneOnOnes,
             'contractRenewals' => $contractRenewals,
-            'timesheetApprovals' => $timesheetApprovals,
+            'timesheetsStats' => $timesheetsStats,
             'defaultCompanyCurrency' => $company->currency,
         ]);
     }

--- a/app/Http/Controllers/Company/Dashboard/DashboardManagerController.php
+++ b/app/Http/Controllers/Company/Dashboard/DashboardManagerController.php
@@ -57,6 +57,7 @@ class DashboardManagerController extends Controller
             'dashboard_view' => 'manager',
             'is_manager' => true,
             'can_manage_expenses' => $employee->can_manage_expenses,
+            'can_manage_hr' => $employee->permission_level <= config('officelife.permission_level.hr'),
         ];
 
         $pendingExpenses = DashboardManagerViewHelper::pendingExpenses($employee, $directReports);

--- a/app/Http/Controllers/Company/Dashboard/DashboardManagerTimesheetController.php
+++ b/app/Http/Controllers/Company/Dashboard/DashboardManagerTimesheetController.php
@@ -58,7 +58,7 @@ class DashboardManagerTimesheetController extends Controller
      *
      * @param Request $request
      * @param int $companyId
-     * @param int $expenseId
+     * @param int $timesheetId
      *
      * @return \Illuminate\Http\RedirectResponse|\Illuminate\Routing\Redirector|Response
      */

--- a/app/Http/Controllers/Company/Dashboard/DashboardManagerTimesheetController.php
+++ b/app/Http/Controllers/Company/Dashboard/DashboardManagerTimesheetController.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace App\Http\Controllers\Company\Dashboard;
+
+use Inertia\Inertia;
+use Inertia\Response;
+use Illuminate\Http\Request;
+use App\Helpers\InstanceHelper;
+use App\Models\Company\Company;
+use App\Models\Company\Employee;
+use App\Models\Company\Timesheet;
+use Illuminate\Http\JsonResponse;
+use App\Helpers\NotificationHelper;
+use App\Http\Controllers\Controller;
+use App\Models\Company\DirectReport;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use App\Services\Company\Employee\Timesheet\RejectTimesheet;
+use App\Services\Company\Employee\Timesheet\ApproveTimesheet;
+use App\Http\ViewHelpers\Dashboard\DashboardTimesheetViewHelper;
+use App\Http\ViewHelpers\Dashboard\Manager\DashboardManagerTimesheetViewHelper;
+
+class DashboardManagerTimesheetController extends Controller
+{
+    /**
+     * Show the list of timesheets to validate.
+     *
+     * @return mixed
+     */
+    public function index()
+    {
+        $company = InstanceHelper::getLoggedCompany();
+        $employee = InstanceHelper::getLoggedEmployee();
+
+        // is the user a manager?
+        $directReports = DirectReport::where('company_id', $company->id)
+            ->where('manager_id', $employee->id)
+            ->with('directReport')
+            ->with('directReport.timesheets')
+            ->get();
+
+        if ($directReports->count() == 0) {
+            return redirect('home');
+        }
+
+        $timesheetApprovals = DashboardManagerTimesheetViewHelper::timesheetApprovals($employee, $directReports);
+
+        return Inertia::render('Dashboard/Manager/Timesheets/Index', [
+            'employee' => [
+                'id' => $employee->id,
+            ],
+            'notifications' => NotificationHelper::getNotifications($employee),
+            'directReports' => $timesheetApprovals,
+        ]);
+    }
+
+    /**
+     * Show the timesheet to validate.
+     *
+     * @param Request $request
+     * @param int $companyId
+     * @param int $expenseId
+     *
+     * @return \Illuminate\Http\RedirectResponse|\Illuminate\Routing\Redirector|Response
+     */
+    public function show(Request $request, int $companyId, int $timesheetId)
+    {
+        $company = InstanceHelper::getLoggedCompany();
+        $employee = InstanceHelper::getLoggedEmployee();
+
+        $timesheet = $this->canAccess($company, $timesheetId, $employee);
+
+        $timesheetInformation = DashboardTimesheetViewHelper::show($timesheet);
+        $daysInHeader = DashboardTimesheetViewHelper::daysHeader($timesheet);
+        $approverInformation = DashboardTimesheetViewHelper::approverInformation($timesheet);
+
+        return Inertia::render('Dashboard/Manager/Timesheets/Show', [
+            'employee' => [
+                'id' => $employee->id,
+                'name' => $employee->name,
+            ],
+            'daysHeader' => $daysInHeader,
+            'timesheet' => $timesheetInformation,
+            'approverInformation' => $approverInformation,
+            'notifications' => NotificationHelper::getNotifications($employee),
+        ]);
+    }
+
+    /**
+     * Approve the timesheet.
+     *
+     * @param Request $request
+     * @param int $companyId
+     * @param int $timesheetId
+     * @return JsonResponse
+     */
+    public function approve(Request $request, int $companyId, int $timesheetId): JsonResponse
+    {
+        $company = InstanceHelper::getLoggedCompany();
+        $employee = InstanceHelper::getLoggedEmployee();
+
+        $timesheet = $this->canAccess($company, $timesheetId, $employee);
+
+        $data = [
+            'company_id' => $company->id,
+            'author_id' => $employee->id,
+            'employee_id' => $timesheet->employee->id,
+            'timesheet_id' => $timesheetId,
+        ];
+
+        $timesheet = (new ApproveTimesheet)->execute($data);
+
+        return response()->json([
+            'data' => $timesheet->id,
+        ], 201);
+    }
+
+    /**
+     * Reject the timesheet.
+     *
+     * @param Request $request
+     * @param int $companyId
+     * @param int $timesheetId
+     * @return JsonResponse
+     */
+    public function reject(Request $request, int $companyId, int $timesheetId): JsonResponse
+    {
+        $company = InstanceHelper::getLoggedCompany();
+        $employee = InstanceHelper::getLoggedEmployee();
+
+        $timesheet = $this->canAccess($company, $timesheetId, $employee);
+
+        $data = [
+            'company_id' => $company->id,
+            'author_id' => $employee->id,
+            'employee_id' => $timesheet->employee->id,
+            'timesheet_id' => $timesheetId,
+        ];
+
+        $timesheet = (new RejectTimesheet)->execute($data);
+
+        return response()->json([
+            'data' => $timesheet->id,
+        ], 201);
+    }
+
+    /**
+     * Check that the current employee has access to this method.
+     * @param Company $company
+     * @param int $timesheetId
+     * @param Employee $employee
+     * @return mixed
+     */
+    private function canAccess(Company $company, int $timesheetId, Employee $employee)
+    {
+        try {
+            $timesheet = Timesheet::where('company_id', $company->id)
+                ->findOrFail($timesheetId);
+        } catch (ModelNotFoundException $e) {
+            return redirect('home');
+        }
+
+        if ($timesheet->status !== Timesheet::READY_TO_SUBMIT) {
+            return redirect('home');
+        }
+
+        // is the user a manager?
+        $directReports = DirectReport::where('company_id', $company->id)
+            ->where('manager_id', $employee->id)
+            ->with('directReport')
+            ->with('directReport.timesheets')
+            ->get();
+
+        if ($directReports->count() == 0) {
+            return redirect('home');
+        }
+
+        // can the manager see this timesheet?
+        if (! $employee->isManagerOf($timesheet->employee->id)) {
+            return redirect('home');
+        }
+
+        return $timesheet;
+    }
+}

--- a/app/Http/Controllers/Company/Dashboard/DashboardMeController.php
+++ b/app/Http/Controllers/Company/Dashboard/DashboardMeController.php
@@ -42,6 +42,7 @@ class DashboardMeController extends Controller
             'is_manager' => $employee->directReports->count() > 0,
             'has_worked_from_home_today' => WorkFromHomeHelper::hasWorkedFromHomeOnDate($employee, Carbon::now()),
             'question' => DashboardMeViewHelper::question($employee),
+            'can_manage_hr' => $employee->permission_level <= config('officelife.permission_level.hr'),
         ];
 
         $defaultCompanyCurrency = [

--- a/app/Http/Controllers/Company/Dashboard/DashboardTeamController.php
+++ b/app/Http/Controllers/Company/Dashboard/DashboardTeamController.php
@@ -51,6 +51,7 @@ class DashboardTeamController extends Controller
             'dashboard_view' => 'team',
             'can_manage_expenses' => $employee->can_manage_expenses,
             'is_manager' => $employee->directReports->count() > 0,
+            'can_manage_hr' => $employee->permission_level <= config('officelife.permission_level.hr'),
         ];
 
         UpdateDashboardPreference::dispatch([

--- a/app/Http/Controllers/Company/Dashboard/DashboardTimesheetController.php
+++ b/app/Http/Controllers/Company/Dashboard/DashboardTimesheetController.php
@@ -43,6 +43,7 @@ class DashboardTimesheetController extends Controller
             'dashboard_view' => 'timesheet',
             'can_manage_expenses' => $employee->can_manage_expenses,
             'is_manager' => $employee->directReports->count() > 0,
+            'can_manage_hr' => $employee->permission_level <= config('officelife.permission_level.hr'),
         ];
 
         $currentTimesheet = (new CreateOrGetTimesheet)->execute([

--- a/app/Http/ViewHelpers/Company/Project/ProjectTasksViewHelper.php
+++ b/app/Http/ViewHelpers/Company/Project/ProjectTasksViewHelper.php
@@ -3,6 +3,7 @@
 namespace App\Http\ViewHelpers\Company\Project;
 
 use App\Helpers\DateHelper;
+use App\Helpers\TimeHelper;
 use App\Models\Company\Company;
 use App\Models\Company\Project;
 use Illuminate\Support\Collection;
@@ -25,6 +26,7 @@ class ProjectTasksViewHelper
             ->with('list')
             ->with('assignee')
             ->with('author')
+            ->with('timeTrackingEntries')
             ->get();
 
         // the goal of the following is to first display tasks without lists,
@@ -82,10 +84,18 @@ class ProjectTasksViewHelper
         return self::getTaskInfo($task, $company);
     }
 
+    /**
+     * Internal method used to populate the project information.
+     *
+     * @param ProjectTask $task
+     * @param Company $company
+     * @return array
+     */
     private static function getTaskInfo(ProjectTask $task, Company $company): array
     {
         $author = $task->author;
         $assignee = $task->assignee;
+        $duration = TimeHelper::convertToHoursAndMinutes($task->timeTrackingEntries()->sum('duration'));
 
         return [
             'id' => $task->id,
@@ -93,6 +103,7 @@ class ProjectTasksViewHelper
             'description' => $task->description,
             'completed' => $task->completed,
             'completed_at' => $task->completed_at ? DateHelper::formatDate($task->completed_at) : null,
+            'duration' => TimeHelper::durationInHumanFormat($duration),
             'author' => $author ? [
                 'id' => $author->id,
                 'name' => $author->name,

--- a/app/Http/ViewHelpers/Dashboard/DashboardHRViewHelper.php
+++ b/app/Http/ViewHelpers/Dashboard/DashboardHRViewHelper.php
@@ -5,7 +5,6 @@ namespace App\Http\ViewHelpers\Dashboard;
 use Carbon\Carbon;
 use App\Models\Company\Company;
 use App\Models\Company\Timesheet;
-use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 
 class DashboardHRViewHelper
@@ -15,9 +14,9 @@ class DashboardHRViewHelper
      * have managers, before the current week.
      *
      * @param Company $company
-     * @return Collection|null
+     * @return array|null
      */
-    public static function employeesWithoutManagersWithPendingTimesheets(Company $company): Collection
+    public static function employeesWithoutManagersWithPendingTimesheets(Company $company): array
     {
         // all the unapproved timesheets of employees without managers
         // except for the current week
@@ -40,6 +39,7 @@ class DashboardHRViewHelper
 
         $timesheetsWithUniqueEmployees = $timesheets->unique('employee_id');
         $timesheetsWithUniqueEmployees = $timesheetsWithUniqueEmployees->whereNotIn('employee_id', $listOfEmployeesWithManagers);
+        $timesheetsLeft = $timesheets->whereNotIn('employee_id', $listOfEmployeesWithManagers);
 
         $employeesCollection = collect([]);
         foreach ($timesheetsWithUniqueEmployees as $timesheet) {
@@ -52,7 +52,13 @@ class DashboardHRViewHelper
             ]);
         }
 
-        return $employeesCollection;
+        return [
+            'number_of_timesheets' => $timesheetsLeft->count(),
+            'employees' => $employeesCollection,
+            'url_view_all' => route('dashboard.hr.timesheet.index', [
+                'company' => $company,
+            ]),
+        ];
     }
 
     public static function statisticsAboutTimesheets(Company $company)

--- a/app/Http/ViewHelpers/Dashboard/DashboardHRViewHelper.php
+++ b/app/Http/ViewHelpers/Dashboard/DashboardHRViewHelper.php
@@ -14,15 +14,17 @@ class DashboardHRViewHelper
      * have managers, before the current week.
      *
      * @param Company $company
-     * @return array|null
+     * @return array
      */
     public static function employeesWithoutManagersWithPendingTimesheets(Company $company): array
     {
         // all the unapproved timesheets of employees without managers
         // except for the current week
-        // this query is not super optimal. ideally, we would query timesheets +
-        // employees without a manager in a single query, but I don’t know how
-        // yet.
+        // this query is tricky and i don’t know how to do it efficiently with
+        // eloquent. so the way to go is to fetch the timesheets that are ready
+        // to submit first, then get all the employees with managers, then
+        // remove all those employees from the list of timesheets. that will get
+        // us all the timesheets for employees who don’t have managers.
         $timesheets = Timesheet::where('company_id', $company->id)
             ->where('status', Timesheet::READY_TO_SUBMIT)
             ->with('employee')

--- a/app/Http/ViewHelpers/Dashboard/DashboardHRViewHelper.php
+++ b/app/Http/ViewHelpers/Dashboard/DashboardHRViewHelper.php
@@ -32,6 +32,7 @@ class DashboardHRViewHelper
             ->get();
 
         // get the list of employees with manager, that we flatten
+        /** @phpstan-ignore-next-line */
         $listOfEmployeesWithManagers = DB::table('direct_reports')
             ->where('company_id', $company->id)
             ->select('employee_id')

--- a/app/Http/ViewHelpers/Dashboard/DashboardHRViewHelper.php
+++ b/app/Http/ViewHelpers/Dashboard/DashboardHRViewHelper.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Http\ViewHelpers\Dashboard;
+
+use Carbon\Carbon;
+use App\Models\Company\Company;
+use App\Models\Company\Timesheet;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+class DashboardHRViewHelper
+{
+    /**
+     * Get the list of pending validation timesheets for employees who don't
+     * have managers, before the current week.
+     *
+     * @param Company $company
+     * @return Collection|null
+     */
+    public static function employeesWithoutManagersWithPendingTimesheets(Company $company): Collection
+    {
+        // all the unapproved timesheets of employees without managers
+        // except for the current week
+        // this query is not super optimal. ideally, we would query timesheets +
+        // employees without a manager in a single query, but I don’t know how
+        // yet.
+        $timesheets = Timesheet::where('company_id', $company->id)
+            ->where('status', Timesheet::READY_TO_SUBMIT)
+            ->with('employee')
+            ->whereDate('started_at', '<', Carbon::now()->startOfWeek(Carbon::MONDAY))
+            ->get();
+
+        // get the list of employees with manager, that we flatten
+        $listOfEmployeesWithManagers = DB::table('direct_reports')
+            ->where('company_id', $company->id)
+            ->select('employee_id')
+            ->get()
+            ->pluck('employee_id')
+            ->toArray();
+
+        $timesheetsWithUniqueEmployees = $timesheets->unique('employee_id');
+        $timesheetsWithUniqueEmployees = $timesheetsWithUniqueEmployees->whereNotIn('employee_id', $listOfEmployeesWithManagers);
+
+        $employeesCollection = collect([]);
+        foreach ($timesheetsWithUniqueEmployees as $timesheet) {
+            $employee = $timesheet->employee;
+
+            $employeesCollection->push([
+                'id' => $employee->id,
+                'name' => $employee->name,
+                'avatar' => $employee->avatar,
+            ]);
+        }
+
+        return $employeesCollection;
+    }
+
+    public static function statisticsAboutTimesheets(Company $company)
+    {
+        $totals = DB::table('timesheets')
+            ->whereDate('started_at', '>=', Carbon::now()->startOfWeek(Carbon::MONDAY)->subDays(30))
+            ->whereDate('started_at', '<', Carbon::now()->startOfWeek(Carbon::MONDAY))
+            ->selectRaw('count(*) as total')
+            ->selectRaw("count(case when status = '".Timesheet::REJECTED."' then 1 end) as rejected")
+            ->first();
+
+        return [
+            'total' => $totals->total,
+            'rejected' => $totals->rejected,
+        ];
+    }
+}

--- a/app/Http/ViewHelpers/Dashboard/DashboardManagerViewHelper.php
+++ b/app/Http/ViewHelpers/Dashboard/DashboardManagerViewHelper.php
@@ -251,6 +251,10 @@ class DashboardManagerViewHelper
                         'hours' => $arrayOfTime['hours'],
                         'minutes' => $arrayOfTime['minutes'],
                     ]),
+                    'url' => route('dashboard.manager.timesheet.show', [
+                        'company' => $company,
+                        'timesheet' => $timesheet,
+                    ]),
                 ]);
             }
 

--- a/app/Http/ViewHelpers/Dashboard/DashboardManagerViewHelper.php
+++ b/app/Http/ViewHelpers/Dashboard/DashboardManagerViewHelper.php
@@ -4,12 +4,10 @@ namespace App\Http\ViewHelpers\Dashboard;
 
 use Carbon\Carbon;
 use App\Helpers\DateHelper;
-use App\Helpers\TimeHelper;
 use App\Helpers\MoneyHelper;
 use App\Models\Company\Expense;
 use App\Models\Company\Employee;
 use App\Models\Company\Timesheet;
-use Illuminate\Support\Facades\DB;
 use App\Models\Company\OneOnOneEntry;
 use App\Models\Company\EmployeeStatus;
 use Illuminate\Database\Eloquent\Collection;
@@ -216,16 +214,17 @@ class DashboardManagerViewHelper
     }
 
     /**
-     * Get the information about timesheets that need approval.
+     * Get the list of employees who have timesheets to approve by this manager.
      *
      * @param Employee $manager
      * @param Collection $directReports
-     * @return SupportCollection|null
+     * @return array|null
      */
-    public static function timesheetApprovals(Employee $manager, Collection $directReports): ?SupportCollection
+    public static function employeesWithTimesheetsToApprove(Employee $manager, Collection $directReports): ?array
     {
         $employeesCollection = collect([]);
         $company = $manager->company;
+        $totalNumberOfTimesheetsToValidate = 0;
 
         foreach ($directReports as $directReport) {
             $employee = $directReport->directReport;
@@ -235,44 +234,26 @@ class DashboardManagerViewHelper
                 ->orderBy('started_at', 'desc')
                 ->get();
 
-            $timesheetCollection = collect([]);
-            foreach ($pendingTimesheets as $timesheet) {
-                $totalWorkedInMinutes = DB::table('time_tracking_entries')
-                    ->where('timesheet_id', $timesheet->id)
-                    ->sum('duration');
-
-                $arrayOfTime = TimeHelper::convertToHoursAndMinutes($totalWorkedInMinutes);
-
-                $timesheetCollection->push([
-                    'id' => $timesheet->id,
-                    'started_at' => DateHelper::formatDate($timesheet->started_at),
-                    'ended_at' => DateHelper::formatDate($timesheet->ended_at),
-                    'duration' => trans('dashboard.manager_timesheet_approval_duration', [
-                        'hours' => $arrayOfTime['hours'],
-                        'minutes' => $arrayOfTime['minutes'],
-                    ]),
-                    'url' => route('dashboard.manager.timesheet.show', [
-                        'company' => $company,
-                        'timesheet' => $timesheet,
-                    ]),
-                ]);
-            }
+            $totalNumberOfTimesheetsToValidate += $pendingTimesheets->count();
 
             if ($pendingTimesheets->count() !== 0) {
                 $employeesCollection->push([
                     'id' => $employee->id,
-                    'name' => $employee->name,
                     'avatar' => $employee->avatar,
-                    'position' => (! $employee->position) ? null : $employee->position->title,
                     'url' => route('employees.show', [
                         'company' => $company,
                         'employee' => $employee,
                     ]),
-                    'timesheets' => $timesheetCollection,
                 ]);
             }
         }
 
-        return $employeesCollection;
+        return [
+            'totalNumberOfTimesheetsToValidate' => $totalNumberOfTimesheetsToValidate,
+            'employees' => $employeesCollection,
+            'url_view_all'=> route('dashboard.manager.timesheet.index', [
+                'company' => $manager->company,
+            ]),
+        ];
     }
 }

--- a/app/Http/ViewHelpers/Dashboard/HR/DashboardHRTimesheetViewHelper.php
+++ b/app/Http/ViewHelpers/Dashboard/HR/DashboardHRTimesheetViewHelper.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace App\Http\ViewHelpers\Dashboard\HR;
+
+use Carbon\Carbon;
+use App\Helpers\DateHelper;
+use App\Helpers\TimeHelper;
+use App\Models\Company\Company;
+use App\Models\Company\Timesheet;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+class DashboardHRTimesheetViewHelper
+{
+    /**
+     * Get the information about timesheets that need approval for employees who
+     * doesn't have a manager.
+     *
+     * @param Company $company
+     * @return Collection|null
+     */
+    public static function timesheetApprovalsForEmployeesWithoutManagers(Company $company): ?Collection
+    {
+        // all the unapproved timesheets of employees without managers
+        // except for the current week
+        // this query is not super optimal. ideally, we would query timesheets +
+        // employees without a manager in a single query, but I don’t know how
+        // yet.
+        $timesheets = Timesheet::where('company_id', $company->id)
+            ->where('status', Timesheet::READY_TO_SUBMIT)
+            ->with('employee')
+            ->whereDate('started_at', '<', Carbon::now()->startOfWeek(Carbon::MONDAY))
+            ->get();
+
+        // get the list of employees with manager, that we flatten
+        $listOfEmployeesWithManagers = DB::table('direct_reports')
+            ->where('company_id', $company->id)
+            ->select('employee_id')
+            ->get()
+            ->pluck('employee_id')
+            ->toArray();
+
+        $timesheetsWithUniqueEmployees = $timesheets->unique('employee_id');
+        $timesheetsWithUniqueEmployees = $timesheetsWithUniqueEmployees->whereNotIn('employee_id', $listOfEmployeesWithManagers);
+
+        $uniqueEmployeeCollection = collect([]);
+        foreach ($timesheetsWithUniqueEmployees as $timesheet) {
+            $employee = $timesheet->employee;
+            $uniqueEmployeeCollection->push($employee);
+        }
+
+        $employeesCollection = collect([]);
+        foreach ($uniqueEmployeeCollection as $employee) {
+            $pendingTimesheets = $employee->timesheets()
+                ->where('status', Timesheet::READY_TO_SUBMIT)
+                ->orderBy('started_at', 'desc')
+                ->get();
+
+            $timesheetCollection = collect([]);
+            foreach ($pendingTimesheets as $timesheet) {
+                $totalWorkedInMinutes = DB::table('time_tracking_entries')
+                ->where('timesheet_id', $timesheet->id)
+                    ->sum('duration');
+
+                $arrayOfTime = TimeHelper::convertToHoursAndMinutes($totalWorkedInMinutes);
+
+                $timesheetCollection->push([
+                    'id' => $timesheet->id,
+                    'started_at' => DateHelper::formatDate($timesheet->started_at),
+                    'ended_at' => DateHelper::formatDate($timesheet->ended_at),
+                    'duration' => trans('dashboard.manager_timesheet_approval_duration', [
+                        'hours' => $arrayOfTime['hours'],
+                        'minutes' => $arrayOfTime['minutes'],
+                    ]),
+                    'url' => route('dashboard.hr.timesheet.show', [
+                        'company' => $company,
+                        'timesheet' => $timesheet,
+                    ]),
+                ]);
+            }
+
+            if ($pendingTimesheets->count() !== 0) {
+                $employeesCollection->push([
+                    'id' => $employee->id,
+                    'name' => $employee->name,
+                    'avatar' => $employee->avatar,
+                    'position' => (! $employee->position) ? null : $employee->position->title,
+                    'url' => route('employees.show', [
+                        'company' => $company,
+                        'employee' => $employee,
+                    ]),
+                    'timesheets' => $timesheetCollection,
+                ]);
+            }
+        }
+
+        return $employeesCollection;
+    }
+}

--- a/app/Http/ViewHelpers/Dashboard/HR/DashboardHRTimesheetViewHelper.php
+++ b/app/Http/ViewHelpers/Dashboard/HR/DashboardHRTimesheetViewHelper.php
@@ -33,6 +33,7 @@ class DashboardHRTimesheetViewHelper
             ->get();
 
         // get the list of employees with manager, that we flatten
+        /** @phpstan-ignore-next-line */
         $listOfEmployeesWithManagers = DB::table('direct_reports')
             ->where('company_id', $company->id)
             ->select('employee_id')

--- a/app/Http/ViewHelpers/Dashboard/Manager/DashboardManagerTimesheetViewHelper.php
+++ b/app/Http/ViewHelpers/Dashboard/Manager/DashboardManagerTimesheetViewHelper.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Http\ViewHelpers\Dashboard\Manager;
+
+use App\Helpers\DateHelper;
+use App\Helpers\TimeHelper;
+use App\Models\Company\Employee;
+use App\Models\Company\Timesheet;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+class DashboardManagerTimesheetViewHelper
+{
+    /**
+     * Get the information about timesheets that need approval.
+     *
+     * @param Employee $manager
+     * @param Collection $directReports
+     * @return Collection|null
+     */
+    public static function timesheetApprovals(Employee $manager, Collection $directReports): ?Collection
+    {
+        $employeesCollection = collect([]);
+        $company = $manager->company;
+
+        foreach ($directReports as $directReport) {
+            $employee = $directReport->directReport;
+
+            $pendingTimesheets = $employee->timesheets()
+                ->where('status', Timesheet::READY_TO_SUBMIT)
+                ->orderBy('started_at', 'desc')
+                ->get();
+
+            $timesheetCollection = collect([]);
+            foreach ($pendingTimesheets as $timesheet) {
+                $totalWorkedInMinutes = DB::table('time_tracking_entries')
+                ->where('timesheet_id', $timesheet->id)
+                    ->sum('duration');
+
+                $arrayOfTime = TimeHelper::convertToHoursAndMinutes($totalWorkedInMinutes);
+
+                $timesheetCollection->push([
+                    'id' => $timesheet->id,
+                    'started_at' => DateHelper::formatDate($timesheet->started_at),
+                    'ended_at' => DateHelper::formatDate($timesheet->ended_at),
+                    'duration' => trans('dashboard.manager_timesheet_approval_duration', [
+                        'hours' => $arrayOfTime['hours'],
+                        'minutes' => $arrayOfTime['minutes'],
+                    ]),
+                    'url' => route('dashboard.manager.timesheet.show', [
+                        'company' => $company,
+                        'timesheet' => $timesheet,
+                    ]),
+                ]);
+            }
+
+            if ($pendingTimesheets->count() !== 0) {
+                $employeesCollection->push([
+                    'id' => $employee->id,
+                    'name' => $employee->name,
+                    'avatar' => $employee->avatar,
+                    'position' => (! $employee->position) ? null : $employee->position->title,
+                    'url' => route('employees.show', [
+                        'company' => $company,
+                        'employee' => $employee,
+                    ]),
+                    'timesheets' => $timesheetCollection,
+                ]);
+            }
+        }
+
+        return $employeesCollection;
+    }
+}

--- a/app/Http/ViewHelpers/Team/TeamRecentShipViewHelper.php
+++ b/app/Http/ViewHelpers/Team/TeamRecentShipViewHelper.php
@@ -19,7 +19,8 @@ class TeamRecentShipViewHelper
      */
     public static function recentShips(Team $team): Collection
     {
-        $ships = $team->ships()->with('employees')->get();
+        $ships = $team->ships()->orderBy('id', 'desc')->with('employees')->get();
+
         $shipsCollection = collect([]);
         foreach ($ships as $ship) {
             $employees = $ship->employees;

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -23,4 +23,3 @@ parameters:
         - message: '#Cannot access property \$[a-zA-Z0-9_]+ on array.#'
           path: 'app/Helpers/NotificationHelper.php'
         - '#Call to an undefined method Illuminate\\Database\\Eloquent\\Factories\\Factory::[a-zA-Z0-9\\_]+\(\)\.#'
-        - 'Called 'pluck' on Laravel collection[a-zA-Z0-9\\_]+\(\)\.#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -23,3 +23,4 @@ parameters:
         - message: '#Cannot access property \$[a-zA-Z0-9_]+ on array.#'
           path: 'app/Helpers/NotificationHelper.php'
         - '#Call to an undefined method Illuminate\\Database\\Eloquent\\Factories\\Factory::[a-zA-Z0-9\\_]+\(\)\.#'
+        - 'Called 'pluck' on Laravel collection[a-zA-Z0-9\\_]+\(\)\.#'

--- a/resources/js/Pages/Dashboard/HR/Index.vue
+++ b/resources/js/Pages/Dashboard/HR/Index.vue
@@ -1,0 +1,60 @@
+<style scoped>
+.dummy {
+  right: 40px;
+  bottom: 20px;
+}
+</style>
+
+<template>
+  <layout title="Home" :notifications="notifications">
+    <div class="ph2 ph0-ns">
+      <dashboard-menu :employee="employee" />
+    </div>
+
+    <timesheets
+      :data="employeesWithoutManagersWithPendingTimesheets"
+      :statistics="statisticsAboutTimesheets"
+    />
+  </layout>
+</template>
+
+<script>
+import Timesheets from '@/Pages/Dashboard/HR/Partials/Timesheets';
+import Layout from '@/Shared/Layout';
+import DashboardMenu from '@/Pages/Dashboard/Partials/DashboardMenu';
+
+export default {
+  components: {
+    Timesheets,
+    Layout,
+    DashboardMenu,
+  },
+
+  props: {
+    employee: {
+      type: Object,
+      default: null,
+    },
+    notifications: {
+      type: Array,
+      default: null,
+    },
+    employeesWithoutManagersWithPendingTimesheets: {
+      type: Object,
+      default: null,
+    },
+    statisticsAboutTimesheets: {
+      type: Object,
+      default: null,
+    },
+  },
+
+  mounted() {
+    if (localStorage.success) {
+      flash(localStorage.success, 'success');
+
+      localStorage.removeItem('success');
+    }
+  },
+};
+</script>

--- a/resources/js/Pages/Dashboard/HR/Partials/Timesheets.vue
+++ b/resources/js/Pages/Dashboard/HR/Partials/Timesheets.vue
@@ -1,0 +1,92 @@
+<style lang="scss" scoped>
+.entry-item:first-child {
+  border-top-width: 1px;
+  border-top-style: solid;
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px;
+}
+
+.entry-item:last-child {
+  border-bottom-left-radius: 3px;
+  border-bottom-right-radius: 3px;
+}
+
+.avatar {
+  left: 1px;
+  top: 5px;
+  width: 35px;
+}
+
+.team-member {
+  padding-left: 44px;
+
+  .avatar {
+    top: 2px;
+  }
+}
+
+.top-1 {
+  top: 0.3rem;
+}
+</style>
+
+<template>
+  <div class="mb5">
+    <div class="cf mw7 center mb2 fw5 relative">
+      <span class="mr1">
+        ⏲
+      </span> {{ $t('dashboard.hr_timesheets_title') }}
+
+      <help :url="$page.props.help_links.contract_renewal_dashboard" />
+    </div>
+
+    <div class="cf mw7 center br3 mb3 bg-white box relative">
+      <div class="flex justify-between items-center">
+        <!-- stats -->
+        <div>
+          <img loading="lazy" src="/img/streamline-icon-employee-checklist-6@140x140.png" width="90" alt="meeting" class="absolute-ns di-ns dn top-1 left-1" />
+
+          <p v-if="data.number_of_timesheets > 0" class="pl6-ns pl3 pb2 pt4 pr3 ma0 lh-copy">
+            {{ $t('dashboard.hr_timesheet_summary_count', { count: data.number_of_timesheets}) }}
+          </p>
+          <p v-else class="pl6-ns pl3 pb4 pt4 pr3 mb2">
+            {{ $t('dashboard.hr_timesheet_summary_blank') }}
+          </p>
+
+          <!-- avatars -->
+          <div v-if="data.number_of_timesheets > 0" class="pl6-ns pl3 mb3">
+            <div class="flex items-center relative tr all-avatars">
+              <img v-for="member in data.employees" :key="member.id" :src="member.avatar" alt="avatar" class="br-100 small-avatar"
+                   width="32" height="32"
+              />
+            </div>
+          </div>
+        </div>
+
+        <!-- CTA -->
+        <inertia-link :href="data.url_view_all" class="btn w-auto-ns w-100 mr2 pv2 ph3 mr3">{{ $t('app.view') }}</inertia-link>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import Help from '@/Shared/Help';
+
+export default {
+  components: {
+    Help,
+  },
+
+  props: {
+    data: {
+      type: Object,
+      default: null,
+    },
+    statistics: {
+      type: Object,
+      default: null,
+    },
+  },
+};
+</script>

--- a/resources/js/Pages/Dashboard/HR/Timesheets/Index.vue
+++ b/resources/js/Pages/Dashboard/HR/Timesheets/Index.vue
@@ -1,0 +1,210 @@
+<style lang="scss" scoped>
+.entry-item:first-child {
+  border-top-width: 1px;
+  border-top-style: solid;
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px;
+}
+
+.entry-item:last-child {
+  border-bottom-left-radius: 3px;
+  border-bottom-right-radius: 3px;
+  margin-bottom: 20px;
+}
+
+.direct-report-item:not(:first-child) {
+  margin-top: 30px;
+}
+
+.avatar {
+  left: 1px;
+  top: 5px;
+  width: 35px;
+}
+
+.team-member {
+  padding-left: 44px;
+
+  .avatar {
+    top: 2px;
+  }
+}
+
+.top-1 {
+  top: 20px;
+}
+</style>
+
+<template>
+  <layout title="Home" :notifications="notifications">
+    <div class="ph2 ph0-ns">
+      <!-- BREADCRUMB -->
+      <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">
+        <ul class="list ph0 tc-l tl">
+          <li class="di">
+            <inertia-link :href="'/' + $page.props.auth.company.id + '/dashboard'">{{ $t('app.breadcrumb_dashboard') }}</inertia-link>
+          </li>
+          <li class="di">
+            <inertia-link :href="'/' + $page.props.auth.company.id + '/dashboard/hr'">{{ $t('app.breadcrumb_dashboard_hr') }}</inertia-link>
+          </li>
+          <li class="di">
+            {{ $t('app.breadcrumb_dashboard_manager_timesheets') }}
+          </li>
+        </ul>
+      </div>
+
+      <!-- BODY -->
+      <div class="mw7 center br3 mb5 bg-white box relative z-1">
+        <h2 class="pa3 mt2 mb3 center tc normal">
+          {{ $t('dashboard.hr_timesheet_index_title') }}
+          <help :url="$page.props.help_links.one_on_ones" :top="'0px'" />
+        </h2>
+
+        <!-- BLANK STATE -->
+        <div v-if="displayBlankState" data-cy="expense-list-blank-state">
+          <img loading="lazy" class="db center mb4 mt3" alt="no timesheets to validate" src="/img/streamline-icon-employee-checklist-6@140x140.png" height="80"
+               width="80"
+          />
+
+          <p class="fw5 mt3 tc">{{ $t('dashboard.manager_timesheet_blank_state') }}</p>
+        </div>
+
+        <!-- NOT BLANK STATE :-) -->
+        <div v-else>
+          <img loading="lazy" src="/img/streamline-icon-employee-checklist-6@140x140.png" width="90" alt="meeting" class="absolute-ns di-ns dn top-1 left-1" />
+
+          <ul class="pl6-ns pl3 pb3 pt3 pr3 ma0">
+            <li v-for="directReport in localEmployees" :key="directReport.id" class="list ma0 direct-report-item">
+              <!-- identity -->
+              <div class="mb3">
+                <span class="pl3 db relative team-member">
+                  <img loading="lazy" :src="directReport.avatar" alt="avatar" class="br-100 absolute avatar" />
+                  <inertia-link :href="directReport.url" class="mb2">{{ directReport.name }}</inertia-link>
+                  <span class="title db f7 mt1">
+                    {{ directReport.position }}
+                  </span>
+                </span>
+              </div>
+
+              <!-- list of timesheets -->
+              <ul>
+                <li v-for="timesheet in directReport.timesheets" :key="timesheet.id" class="flex justify-between items-center br bl bb bb-gray bb-gray-hover pa3 entry-item">
+                  <!-- timesheet info -->
+                  <div>
+                    <p class="ma0 mb2 f7 grey">{{ timesheet.started_at }} → {{ timesheet.ended_at }}</p>
+                    <p class="f4 ma0">{{ timesheet.duration }}</p>
+                  </div>
+
+                  <!-- timesheet actions -->
+                  <div>
+                    <inertia-link :href="timesheet.url" class="mr2 f7">{{ $t('dashboard.manager_timesheet_view_details') }}</inertia-link>
+                    <loading-button :classes="'btn w-auto-ns w-100 mr2 pv2 ph3'" :state="loadingStateReject" :text="$t('app.reject')" :cypress-selector="'reject-timesheet-' + timesheet.id" @click="reject(timesheet, directReport)" />
+                    <loading-button :classes="'btn w-auto-ns w-100 mr2 pv2 ph3'" :state="loadingStateApprove" :text="$t('app.approve')" :cypress-selector="'approve-timesheet-' + timesheet.id" @click="approve(timesheet, directReport)" />
+                  </div>
+                </li>
+              </ul>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </layout>
+</template>
+
+<script>
+import Layout from '@/Shared/Layout';
+import Help from '@/Shared/Help';
+import LoadingButton from '@/Shared/LoadingButton';
+
+export default {
+  components: {
+    Layout,
+    Help,
+    LoadingButton,
+  },
+
+  props: {
+    notifications: {
+      type: Array,
+      default: null,
+    },
+    employee: {
+      type: Object,
+      default: null,
+    },
+    employees: {
+      type: Array,
+      default: null,
+    },
+  },
+
+  data() {
+    return {
+      loadingStateApprove: '',
+      loadingStateReject: '',
+      localEmployees: null,
+    };
+  },
+
+  computed: {
+    displayBlankState() {
+      if (! this.localEmployees) {
+        return false;
+      }
+
+      if (this.localEmployees.length == 0) {
+        return true;
+      }
+
+      return false;
+    }
+  },
+
+  mounted() {
+    this.localEmployees = this.employees;
+  },
+
+  methods: {
+    approve(timesheet, directReport) {
+      this.loadingStateApprove = 'loading';
+
+      axios.post(`${this.$page.props.auth.company.id}/dashboard/hr/timesheets/${timesheet.id}/approve`)
+        .then(response => {
+          flash(this.$t('dashboard.manager_timesheet_approved'), 'success');
+          this.removeEntry(timesheet, directReport);
+          this.loadingStateApprove = '';
+        })
+        .catch(error => {
+          this.loadingStateApprove = null;
+          this.form.errors = error.response.data;
+        });
+    },
+
+    reject(timesheet, directReport) {
+      this.loadingStateReject = 'loading';
+
+      axios.post(`${this.$page.props.auth.company.id}/dashboard/hr/timesheets/${timesheet.id}/reject`)
+        .then(response => {
+          flash(this.$t('dashboard.manager_timesheet_rejected'), 'success');
+          this.removeEntry(timesheet, directReport);
+          this.loadingStateReject = '';
+        })
+        .catch(error => {
+          this.loadingStateReject = null;
+          this.form.errors = error.response.data;
+        });
+    },
+
+    removeEntry(timesheet, directReport) {
+      var id = this.localEmployees.findIndex(x => x.id == directReport.id);
+      var timesheetId = this.localEmployees[id].timesheets.findIndex(x => x.id == timesheet.id);
+      this.localEmployees[id].timesheets.splice(timesheetId, 1);
+
+      // make sure that the direct report disappears from the list if all the timesheets have been approved
+      if (this.localEmployees[id].timesheets.length == 0) {
+        this.localEmployees.splice(id, 1);
+      }
+    }
+  },
+};
+</script>

--- a/resources/js/Pages/Dashboard/HR/Timesheets/Show.vue
+++ b/resources/js/Pages/Dashboard/HR/Timesheets/Show.vue
@@ -43,7 +43,7 @@
             ...
           </li>
           <li class="di">
-            <inertia-link :href="'/' + $page.props.auth.company.id + '/dashboard/manager/timesheets'">{{ $t('app.breadcrumb_employee_timesheets') }}</inertia-link>
+            <inertia-link :href="'/' + $page.props.auth.company.id + '/dashboard/hr/timesheets'">{{ $t('app.breadcrumb_employee_timesheets') }}</inertia-link>
           </li>
           <li class="di">
             {{ $t('app.breadcrumb_employee_timesheet') }}

--- a/resources/js/Pages/Dashboard/Manager/Index.vue
+++ b/resources/js/Pages/Dashboard/Manager/Index.vue
@@ -12,7 +12,7 @@
     </div>
 
     <timesheet-approvals
-      :direct-reports="timesheetApprovals"
+      :timesheets-stats="timesheetsStats"
     />
 
     <one-on-one-with-direct-report
@@ -70,8 +70,8 @@ export default {
       type: Array,
       default: null,
     },
-    timesheetApprovals: {
-      type: Array,
+    timesheetsStats: {
+      type: Object,
       default: null,
     },
     defaultCurrency: {

--- a/resources/js/Pages/Dashboard/Manager/Partials/TimesheetApprovals.vue
+++ b/resources/js/Pages/Dashboard/Manager/Partials/TimesheetApprovals.vue
@@ -82,6 +82,7 @@
 
                 <!-- timesheet actions -->
                 <div>
+                  <inertia-link :href="timesheet.url" class="mr2 f7">{{ $t('dashboard.manager_timesheet_view_details') }}</inertia-link>
                   <loading-button :classes="'btn w-auto-ns w-100 mr2 pv2 ph3'" :state="loadingStateReject" :text="$t('app.reject')" :cypress-selector="'reject-timesheet-' + timesheet.id" @click="reject(timesheet, directReport)" />
                   <loading-button :classes="'btn w-auto-ns w-100 mr2 pv2 ph3'" :state="loadingStateApprove" :text="$t('app.approve')" :cypress-selector="'approve-timesheet-' + timesheet.id" @click="approve(timesheet, directReport)" />
                 </div>

--- a/resources/js/Pages/Dashboard/Manager/Partials/TimesheetApprovals.vue
+++ b/resources/js/Pages/Dashboard/Manager/Partials/TimesheetApprovals.vue
@@ -1,37 +1,15 @@
 <style lang="scss" scoped>
-.entry-item:first-child {
-  border-top-width: 1px;
-  border-top-style: solid;
-  border-top-left-radius: 3px;
-  border-top-right-radius: 3px;
-}
-
-.entry-item:last-child {
-  border-bottom-left-radius: 3px;
-  border-bottom-right-radius: 3px;
-  margin-bottom: 20px;
-}
-
-.direct-report-item:not(:first-child) {
-  margin-top: 30px;
-}
-
-.avatar {
-  left: 1px;
-  top: 5px;
-  width: 35px;
-}
-
-.team-member {
-  padding-left: 44px;
-
-  .avatar {
-    top: 2px;
-  }
-}
-
 .top-1 {
   top: 20px;
+}
+
+.small-avatar {
+  margin-left: -8px;
+  box-shadow: 0 0 0 2px #fff;
+}
+
+.all-avatars {
+  left: 10px;
 }
 </style>
 
@@ -47,49 +25,36 @@
 
     <div class="cf mw7 center br3 mb3 bg-white box relative">
       <!-- BLANK STATE -->
-      <div v-if="displayBlankState" data-cy="expense-list-blank-state">
-        <img loading="lazy" class="db center mb4 mt3" alt="no timesheets to validate" src="/img/streamline-icon-employee-checklist-6@140x140.png" height="140" />
+      <div v-if="timesheetsStats.employees.length == 0" data-cy="expense-list-blank-state">
+        <img loading="lazy" class="db center mb4 mt3" alt="no timesheets to validate" src="/img/streamline-icon-employee-checklist-6@140x140.png" height="80"
+             width="80"
+        />
 
         <p class="fw5 mt3 tc">{{ $t('dashboard.manager_timesheet_blank_state') }}</p>
       </div>
 
       <!-- NOT BLANK STATE :-) -->
-      <div v-else>
-        <img loading="lazy" src="/img/streamline-icon-employee-checklist-6@140x140.png" width="90" alt="meeting" class="absolute-ns di-ns dn top-1 left-1" />
+      <div v-else class="flex justify-between items-center">
+        <!-- stats -->
+        <div>
+          <img loading="lazy" src="/img/streamline-icon-employee-checklist-6@140x140.png" width="90" alt="meeting" class="absolute-ns di-ns dn top-1 left-1" />
 
-        <ul class="pl6-ns pl3 pb3 pt3 pr3 ma0">
-          <li v-for="directReport in localDirectReports" :key="directReport.id" class="list ma0 direct-report-item">
-            <!-- identity -->
-            <div class="mb3">
-              <span class="pl3 db relative team-member">
+          <p class="pl6-ns pl3 pb3 pt4 pr3 ma0">
+            {{ $t('dashboard.manager_timesheet_summary_count', { count: timesheetsStats.totalNumberOfTimesheetsToValidate}) }}
+          </p>
 
-                <img loading="lazy" :src="directReport.avatar" alt="avatar" class="br-100 absolute avatar" />
-                <inertia-link :href="directReport.url" class="mb2">{{ directReport.name }}</inertia-link>
-                <span class="title db f7 mt1">
-                  {{ directReport.position }}
-                </span>
-              </span>
+          <!-- avatars -->
+          <div v-if="timesheetsStats.employees.length > 0" class="pl6-ns pl3 mb3">
+            <div class="flex items-center relative tr all-avatars">
+              <img v-for="member in timesheetsStats.employees" :key="member.id" :src="member.avatar" alt="avatar" class="br-100 small-avatar"
+                   width="32" height="32"
+              />
             </div>
+          </div>
+        </div>
 
-            <!-- list of timesheets -->
-            <ul>
-              <li v-for="timesheet in directReport.timesheets" :key="timesheet.id" class="flex justify-between items-center br bl bb bb-gray bb-gray-hover pa3 entry-item">
-                <!-- timesheet info -->
-                <div>
-                  <p class="ma0 mb2 f7 grey">{{ timesheet.started_at }} → {{ timesheet.ended_at }}</p>
-                  <p class="f4 ma0">{{ timesheet.duration }}</p>
-                </div>
-
-                <!-- timesheet actions -->
-                <div>
-                  <inertia-link :href="timesheet.url" class="mr2 f7">{{ $t('dashboard.manager_timesheet_view_details') }}</inertia-link>
-                  <loading-button :classes="'btn w-auto-ns w-100 mr2 pv2 ph3'" :state="loadingStateReject" :text="$t('app.reject')" :cypress-selector="'reject-timesheet-' + timesheet.id" @click="reject(timesheet, directReport)" />
-                  <loading-button :classes="'btn w-auto-ns w-100 mr2 pv2 ph3'" :state="loadingStateApprove" :text="$t('app.approve')" :cypress-selector="'approve-timesheet-' + timesheet.id" @click="approve(timesheet, directReport)" />
-                </div>
-              </li>
-            </ul>
-          </li>
-        </ul>
+        <!-- CTA -->
+        <inertia-link :href="timesheetsStats.url_view_all" class="btn w-auto-ns w-100 mr2 pv2 ph3 mr3">{{ $t('app.view') }}</inertia-link>
       </div>
     </div>
   </div>
@@ -97,12 +62,10 @@
 
 <script>
 import Help from '@/Shared/Help';
-import LoadingButton from '@/Shared/LoadingButton';
 
 export default {
   components: {
     Help,
-    LoadingButton,
   },
 
   props: {
@@ -110,79 +73,10 @@ export default {
       type: Object,
       default: null,
     },
-    directReports: {
-      type: Array,
+    timesheetsStats: {
+      type: Object,
       default: null,
     },
-  },
-
-  data() {
-    return {
-      loadingStateApprove: '',
-      loadingStateReject: '',
-      localDirectReports: null,
-    };
-  },
-
-  computed: {
-    displayBlankState() {
-      if (! this.localDirectReports) {
-        return false;
-      }
-
-      if (this.localDirectReports.length == 0) {
-        return true;
-      }
-
-      return false;
-    }
-  },
-
-  mounted() {
-    this.localDirectReports = this.directReports;
-  },
-
-  methods: {
-    approve(timesheet, directReport) {
-      this.loadingStateApprove = 'loading';
-
-      axios.post(`${this.$page.props.auth.company.id}/dashboard/manager/timesheets/${timesheet.id}/approve`)
-        .then(response => {
-          flash(this.$t('dashboard.manager_timesheet_approved'), 'success');
-          this.removeEntry(timesheet, directReport);
-          this.loadingStateApprove = '';
-        })
-        .catch(error => {
-          this.loadingStateApprove = null;
-          this.form.errors = error.response.data;
-        });
-    },
-
-    reject(timesheet, directReport) {
-      this.loadingStateReject = 'loading';
-
-      axios.post(`${this.$page.props.auth.company.id}/dashboard/manager/timesheets/${timesheet.id}/reject`)
-        .then(response => {
-          flash(this.$t('dashboard.manager_timesheet_rejected'), 'success');
-          this.removeEntry(timesheet, directReport);
-          this.loadingStateReject = '';
-        })
-        .catch(error => {
-          this.loadingStateReject = null;
-          this.form.errors = error.response.data;
-        });
-    },
-
-    removeEntry(timesheet, directReport) {
-      var id = this.localDirectReports.findIndex(x => x.id == directReport.id);
-      var timesheetId = this.localDirectReports[id].timesheets.findIndex(x => x.id == timesheet.id);
-      this.localDirectReports[id].timesheets.splice(timesheetId, 1);
-
-      // make sure that the direct report disappears from the list if all the timesheets have been approved
-      if (this.localDirectReports[id].timesheets.length == 0) {
-        this.localDirectReports.splice(id, 1);
-      }
-    }
   },
 };
 </script>

--- a/resources/js/Pages/Dashboard/Manager/Timesheets/Index.vue
+++ b/resources/js/Pages/Dashboard/Manager/Timesheets/Index.vue
@@ -1,0 +1,211 @@
+<style lang="scss" scoped>
+.entry-item:first-child {
+  border-top-width: 1px;
+  border-top-style: solid;
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px;
+}
+
+.entry-item:last-child {
+  border-bottom-left-radius: 3px;
+  border-bottom-right-radius: 3px;
+  margin-bottom: 20px;
+}
+
+.direct-report-item:not(:first-child) {
+  margin-top: 30px;
+}
+
+.avatar {
+  left: 1px;
+  top: 5px;
+  width: 35px;
+}
+
+.team-member {
+  padding-left: 44px;
+
+  .avatar {
+    top: 2px;
+  }
+}
+
+.top-1 {
+  top: 20px;
+}
+</style>
+
+<template>
+  <layout title="Home" :notifications="notifications">
+    <div class="ph2 ph0-ns">
+      <!-- BREADCRUMB -->
+      <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">
+        <ul class="list ph0 tc-l tl">
+          <li class="di">
+            <inertia-link :href="'/' + $page.props.auth.company.id + '/dashboard'">{{ $t('app.breadcrumb_dashboard') }}</inertia-link>
+          </li>
+          <li class="di">
+            <inertia-link :href="'/' + $page.props.auth.company.id + '/dashboard/manager'">{{ $t('app.breadcrumb_dashboard_manager') }}</inertia-link>
+          </li>
+          <li class="di">
+            {{ $t('app.breadcrumb_dashboard_manager_timesheets') }}
+          </li>
+        </ul>
+      </div>
+
+      <!-- BODY -->
+      <div class="mw7 center br3 mb5 bg-white box relative z-1">
+        <h2 class="pa3 mt2 mb3 center tc normal">
+          {{ $t('dashboard.manager_timesheet_index_title') }}
+
+          <help :url="$page.props.help_links.one_on_ones" :top="'0px'" />
+        </h2>
+
+        <!-- BLANK STATE -->
+        <div v-if="displayBlankState" data-cy="expense-list-blank-state">
+          <img loading="lazy" class="db center mb4 mt3" alt="no timesheets to validate" src="/img/streamline-icon-employee-checklist-6@140x140.png" height="80"
+               width="80"
+          />
+
+          <p class="fw5 mt3 tc">{{ $t('dashboard.manager_timesheet_blank_state') }}</p>
+        </div>
+
+        <!-- NOT BLANK STATE :-) -->
+        <div v-else>
+          <img loading="lazy" src="/img/streamline-icon-employee-checklist-6@140x140.png" width="90" alt="meeting" class="absolute-ns di-ns dn top-1 left-1" />
+
+          <ul class="pl6-ns pl3 pb3 pt3 pr3 ma0">
+            <li v-for="directReport in localDirectReports" :key="directReport.id" class="list ma0 direct-report-item">
+              <!-- identity -->
+              <div class="mb3">
+                <span class="pl3 db relative team-member">
+                  <img loading="lazy" :src="directReport.avatar" alt="avatar" class="br-100 absolute avatar" />
+                  <inertia-link :href="directReport.url" class="mb2">{{ directReport.name }}</inertia-link>
+                  <span class="title db f7 mt1">
+                    {{ directReport.position }}
+                  </span>
+                </span>
+              </div>
+
+              <!-- list of timesheets -->
+              <ul>
+                <li v-for="timesheet in directReport.timesheets" :key="timesheet.id" class="flex justify-between items-center br bl bb bb-gray bb-gray-hover pa3 entry-item">
+                  <!-- timesheet info -->
+                  <div>
+                    <p class="ma0 mb2 f7 grey">{{ timesheet.started_at }} → {{ timesheet.ended_at }}</p>
+                    <p class="f4 ma0">{{ timesheet.duration }}</p>
+                  </div>
+
+                  <!-- timesheet actions -->
+                  <div>
+                    <inertia-link :href="timesheet.url" class="mr2 f7">{{ $t('dashboard.manager_timesheet_view_details') }}</inertia-link>
+                    <loading-button :classes="'btn w-auto-ns w-100 mr2 pv2 ph3'" :state="loadingStateReject" :text="$t('app.reject')" :cypress-selector="'reject-timesheet-' + timesheet.id" @click="reject(timesheet, directReport)" />
+                    <loading-button :classes="'btn w-auto-ns w-100 mr2 pv2 ph3'" :state="loadingStateApprove" :text="$t('app.approve')" :cypress-selector="'approve-timesheet-' + timesheet.id" @click="approve(timesheet, directReport)" />
+                  </div>
+                </li>
+              </ul>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </layout>
+</template>
+
+<script>
+import Layout from '@/Shared/Layout';
+import Help from '@/Shared/Help';
+import LoadingButton from '@/Shared/LoadingButton';
+
+export default {
+  components: {
+    Layout,
+    Help,
+    LoadingButton,
+  },
+
+  props: {
+    notifications: {
+      type: Array,
+      default: null,
+    },
+    employee: {
+      type: Object,
+      default: null,
+    },
+    directReports: {
+      type: Array,
+      default: null,
+    },
+  },
+
+  data() {
+    return {
+      loadingStateApprove: '',
+      loadingStateReject: '',
+      localDirectReports: null,
+    };
+  },
+
+  computed: {
+    displayBlankState() {
+      if (! this.localDirectReports) {
+        return false;
+      }
+
+      if (this.localDirectReports.length == 0) {
+        return true;
+      }
+
+      return false;
+    }
+  },
+
+  mounted() {
+    this.localDirectReports = this.directReports;
+  },
+
+  methods: {
+    approve(timesheet, directReport) {
+      this.loadingStateApprove = 'loading';
+
+      axios.post(`${this.$page.props.auth.company.id}/dashboard/manager/timesheets/${timesheet.id}/approve`)
+        .then(response => {
+          flash(this.$t('dashboard.manager_timesheet_approved'), 'success');
+          this.removeEntry(timesheet, directReport);
+          this.loadingStateApprove = '';
+        })
+        .catch(error => {
+          this.loadingStateApprove = null;
+          this.form.errors = error.response.data;
+        });
+    },
+
+    reject(timesheet, directReport) {
+      this.loadingStateReject = 'loading';
+
+      axios.post(`${this.$page.props.auth.company.id}/dashboard/manager/timesheets/${timesheet.id}/reject`)
+        .then(response => {
+          flash(this.$t('dashboard.manager_timesheet_rejected'), 'success');
+          this.removeEntry(timesheet, directReport);
+          this.loadingStateReject = '';
+        })
+        .catch(error => {
+          this.loadingStateReject = null;
+          this.form.errors = error.response.data;
+        });
+    },
+
+    removeEntry(timesheet, directReport) {
+      var id = this.localDirectReports.findIndex(x => x.id == directReport.id);
+      var timesheetId = this.localDirectReports[id].timesheets.findIndex(x => x.id == timesheet.id);
+      this.localDirectReports[id].timesheets.splice(timesheetId, 1);
+
+      // make sure that the direct report disappears from the list if all the timesheets have been approved
+      if (this.localDirectReports[id].timesheets.length == 0) {
+        this.localDirectReports.splice(id, 1);
+      }
+    }
+  },
+};
+</script>

--- a/resources/js/Pages/Dashboard/Manager/Timesheets/Show.vue
+++ b/resources/js/Pages/Dashboard/Manager/Timesheets/Show.vue
@@ -1,0 +1,306 @@
+<style lang="scss" scoped>
+.project {
+  width: 280px;
+  max-width: 400px;
+}
+
+.off-days {
+  color: #4b7682;
+  background-color: #e6f5f9;
+}
+
+.approved {
+  background-color: #E4F7E7;
+  color: #1EAD2F;
+}
+
+.rejected {
+  background-color: #FEEDE7;
+  color: #E93804;
+}
+
+.open,
+.ready_to_submit {
+  background-color: #ececec;
+  color: #99776d;
+}
+
+.stamp {
+  top: -15px;
+}
+</style>
+
+<template>
+  <layout title="Home" :notifications="notifications">
+    <div class="ph2 ph0-ns">
+      <!-- BREADCRUMB -->
+      <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">
+        <ul class="list ph0 tc-l tl">
+          <li class="di">
+            <inertia-link :href="'/' + $page.props.auth.company.id + '/dashboard'">{{ $t('app.breadcrumb_dashboard') }}</inertia-link>
+          </li>
+          <li class="di">
+            ...
+          </li>
+          <li class="di">
+            <inertia-link :href="'/' + $page.props.auth.company.id + '/employees/' + employee.id + '/administration/timesheets'">{{ $t('app.breadcrumb_employee_timesheets') }}</inertia-link>
+          </li>
+          <li class="di">
+            {{ $t('app.breadcrumb_employee_timesheet') }}
+          </li>
+        </ul>
+      </div>
+
+      <!-- BODY -->
+      <div class="cf mw7 center br3 mb3 bg-white box relative pa3">
+        <!-- title -->
+        <div class="title-section mb3">
+          <h2 class="tc fw5 mt0">
+            {{ $t('employee.timesheets_details_show') }}
+
+            <span class="db f6 mt3 mb4 fw4">
+              {{ timesheet.start_date }} → {{ timesheet.end_date }}
+            </span>
+
+            <help :url="$page.props.help_links.one_on_ones" :top="'0px'" />
+          </h2>
+
+          <!-- information to display when timesheet was approved or rejected -->
+          <div v-if="timesheet.status == 'approved' || timesheet.status == 'rejected'" :class="'relative pa3 mb3 br3 flex items-center justify-around ' + timesheet.status">
+            <img v-if="timesheet.status == 'rejected'" src="/img/streamline-icon-stamp@140x140.png" alt="rejected" height="80" width="80"
+                 class="absolute stamp bg-white br-100 ba b--gray"
+            />
+            <img v-else src="/img/streamline-icon-approve-document@140x140.png" alt="approved" height="80" width="80"
+                 class="absolute stamp bg-white br-100 ba b--gray"
+            />
+
+            <!-- approver name -->
+            <div>
+              <p v-if="timesheet.status == 'approved'" class="ttu f7 mb1 mt0">{{ $t('dashboard.timesheet_approved_by') }}</p>
+              <p v-else class="ttu f7 mb1 mt0">{{ $t('dashboard.timesheet_rejected_by') }}</p>
+
+              <inertia-link v-if="hasID" :href="approverInformation.url" class="ma0">{{ approverInformation.name }}</inertia-link>
+              <p v-else class="ma0">{{ approverInformation.name }}</p>
+            </div>
+
+            <!-- approved date -->
+            <div>
+              <p v-if="timesheet.status == 'approved'" class="ttu f7 mb1 mt0">{{ $t('dashboard.timesheet_approved_on') }}</p>
+              <p v-else class="ttu f7 mb1 mt0">{{ $t('dashboard.timesheet_rejected_on') }}</p>
+              <p class="ma0">{{ approverInformation.approved_at }}</p>
+            </div>
+          </div>
+
+          <!-- information to display when timesheet is not yet approved or  -->
+          <div v-if="timesheet.status == 'open' || timesheet.status == 'ready_to_submit'" :class="'relative pa3 mb3 br3 flex items-center ' + timesheet.status">
+            <img src="/img/streamline-icon-employee-planner-3@140x140.png" alt="stamp" height="80" width="80"
+                 class="relative stamp bg-white br-100 ba b--gray" style="top: 0;"
+            />
+
+            <!-- Status -->
+            <div class="pl4">
+              <p class="ttu f7 mb1 mt0">{{ $t('employee.timesheets_details_status') }}</p>
+              <p class="ma0">{{ $t('employee.timesheets_details_status_' + timesheet.status) }}</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="dt bt br bb-gray w-100">
+          <!-- header -->
+          <timesheet-header :days="daysHeader" />
+
+          <!-- row -->
+          <div v-for="row in timesheet.entries" :key="row.id" class="dt-row">
+            <div class="project f6 ph2 pv3 dtc bl bb bb-gray v-mid">
+              <div class="flex justify-between items-center">
+                <div>
+                  <span class="db pb1 fw5 lh-copy">
+                    {{ row.task_title }}
+                  </span>
+                  <inertia-link :href="row.project_url" class="dib">
+                    {{ row.project_name }}
+                  </inertia-link>
+                </div>
+                <span class="f7 fw5">
+                  {{ formatTime(row.total_this_week) }}
+                </span>
+              </div>
+            </div>
+
+            <!-- monday -->
+            <div class="ph2 pv2 dtc bl bb bb-gray v-mid tc">
+              {{ formatTime(row.days[0].total_of_minutes) }}
+            </div>
+
+            <!-- tuesday -->
+            <div class="ph2 pv2 dtc bl bb bb-gray v-mid tc">
+              {{ formatTime(row.days[1].total_of_minutes) }}
+            </div>
+
+            <!-- wednesday -->
+            <div class="ph2 pv2 dtc bl bb bb-gray v-mid tc">
+              {{ formatTime(row.days[2].total_of_minutes) }}
+            </div>
+
+            <!-- thursday -->
+            <div class="ph2 pv2 dtc bl bb bb-gray v-mid tc">
+              {{ formatTime(row.days[3].total_of_minutes) }}
+            </div>
+
+            <!-- friday -->
+            <div class="ph2 pv2 dtc bl bb bb-gray v-mid tc">
+              {{ formatTime(row.days[4].total_of_minutes) }}
+            </div>
+
+            <!-- saturday -->
+            <div class="ph2 pv2 dtc bl bb bb-gray v-mid off-days tc">
+              {{ formatTime(row.days[5].total_of_minutes) }}
+            </div>
+
+            <!-- sunday -->
+            <div class="ph2 pv2 dtc bl bb bb-gray v-mid off-days tc">
+              {{ formatTime(row.days[6].total_of_minutes) }}
+            </div>
+          </div>
+
+          <!-- total -->
+          <div class="dt-row">
+            <div class="f6 ph2 dtc bt bl bb bb-gray project v-mid">
+              <div class="flex justify-between items-center">
+                <span class="db pb1 fw5">
+                  {{ $t('dashboard.timesheet_total') }}
+                </span>
+                <span class="f7 fw5">
+                  {{ weeklyTotalHumanReadable }}
+                </span>
+              </div>
+            </div>
+
+            <!-- daily total: monday -->
+            <div class="tc pv2 dtc bt bl bb bb-gray f7 gray">
+              {{ formatTime(dailyStats[0]) }}
+            </div>
+            <!-- daily total: tuesday -->
+            <div class="tc pv2 dtc bt bl bb bb-gray f7 gray">
+              {{ formatTime(dailyStats[1]) }}
+            </div>
+            <!-- daily total: wednesday -->
+            <div class="tc pv2 dtc bt bl bb bb-gray f7 gray">
+              {{ formatTime(dailyStats[2]) }}
+            </div>
+            <!-- daily total: thursday -->
+            <div class="tc pv2 dtc bt bl bb bb-gray f7 gray">
+              {{ formatTime(dailyStats[3]) }}
+            </div>
+            <!-- daily total: friday -->
+            <div class="tc pv2 dtc bt bl bb bb-gray f7 gray">
+              {{ formatTime(dailyStats[4]) }}
+            </div>
+            <!-- daily total: saturday -->
+            <div class="tc pv2 dtc bt bl bb bb-gray off-days f7 gray">
+              {{ formatTime(dailyStats[5]) }}
+            </div>
+            <!-- daily total: sunday -->
+            <div class="tc pv2 bt bl bb bb-gray off-days f7 gray">
+              {{ formatTime(dailyStats[6]) }}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </layout>
+</template>
+
+<script>
+import Layout from '@/Shared/Layout';
+import Help from '@/Shared/Help';
+import TimesheetHeader from '@/Pages/Dashboard/Timesheet/Partials/TimesheetHeader';
+
+export default {
+  components: {
+    Layout,
+    Help,
+    TimesheetHeader,
+  },
+
+  props: {
+    notifications: {
+      type: Array,
+      default: null,
+    },
+    employee: {
+      type: Object,
+      default: null,
+    },
+    timesheet: {
+      type: Object,
+      default: null,
+    },
+    daysHeader: {
+      type: Object,
+      default: null,
+    },
+    approverInformation: {
+      type: Array,
+      default: null,
+    },
+  },
+
+  data() {
+    return {
+      weeklyTotalHumanReadable: 0,
+      dailyStats: [0, 0, 0, 0, 0, 0, 0, 0],
+    };
+  },
+
+  computed: {
+    hasID() {
+      return this.containsKey(this.approverInformation, 'id');
+    }
+  },
+
+  mounted() {
+    this.refreshWeeklyTotal();
+    this.refreshDailyTotal();
+  },
+
+  methods: {
+    // check if the object contains a specific key
+    containsKey(obj, key ) {
+      return Object.keys(obj).includes(key);
+    },
+
+    formatTime(timeInMinutes) {
+      var hours = Math.floor(timeInMinutes / 60);
+      var minutes = timeInMinutes % 60;
+
+      // this adds leading zero to minutes, if needed
+      const zeroPad = (num, places) => String(num).padStart(places, '0');
+      return hours + 'h' + zeroPad(minutes, 2);
+    },
+
+    refreshWeeklyTotal() {
+      var total = 0;
+      for(var i = 0; i < this.timesheet.entries.length; i++){
+        total = total + this.timesheet.entries[i].total_this_week;
+      }
+
+      this.weeklyTotalHumanReadable = this.formatTime(total);
+    },
+
+    refreshDailyTotal() {
+      this.dailyStats = [];
+
+      this.timesheet.entries.forEach(row => {
+        for(var day = 0; day < 7; day++) {
+          if (this.dailyStats[day]) {
+            this.dailyStats[day] = parseInt(this.dailyStats[day]) + parseInt(row.days[day].total_of_minutes);
+          } else {
+            this.dailyStats[day] = parseInt(row.days[day].total_of_minutes);
+          }
+        }
+      });
+    },
+  },
+};
+</script>

--- a/resources/js/Pages/Dashboard/Partials/DashboardMenu.vue
+++ b/resources/js/Pages/Dashboard/Partials/DashboardMenu.vue
@@ -16,8 +16,8 @@
       <inertia-link v-if="employee.can_manage_expenses" :href="'/' + $page.props.auth.company.id + '/dashboard/expenses'" class="f6 fl ph3 pv2 dib pointer" :class="{'selected':(employee.dashboard_view == 'expenses')}" data-cy="dashboard-expenses-tab">
         <span class="mr1">🔒</span> {{ $t('dashboard.tab_expenses') }}
       </inertia-link>
-      <inertia-link :href="'/' + $page.props.auth.company.id + '/dashboard/hr'" class="f6 fl ph3 pv2 dib pointer" :class="{'selected':(employee.dashboard_view == 'hr')}" data-cy="dashboard-hr-tab">
-        HR area
+      <inertia-link v-if="employee.can_manage_hr" :href="'/' + $page.props.auth.company.id + '/dashboard/hr'" class="f6 fl ph3 pv2 dib pointer" :class="{'selected':(employee.dashboard_view == 'hr')}" data-cy="dashboard-hr-tab">
+        <span class="mr1">🔒</span> {{ $t('dashboard.tab_hr') }}
       </inertia-link>
     </div>
   </div>

--- a/resources/js/Pages/Dashboard/Timesheet/Index.vue
+++ b/resources/js/Pages/Dashboard/Timesheet/Index.vue
@@ -55,8 +55,8 @@
         <div v-if="rejectedTimesheets" class="mb4 ba bb-gray pa3 br3">
           <p class="mt0 mb2"><span class="mr1">⚠️</span> {{ $t('dashboard.timesheet_rejected_timesheets') }}</p>
           <ul class="list ma0 pl0">
-            <li v-for="timesheet in rejectedTimesheets" :key="timesheet.id" class="dib rejected-timesheet-item mb2 f6 mr2">
-              <inertia-link :href="timesheet.url">{{ timesheet.started_at }}</inertia-link>
+            <li v-for="timesheetItem in rejectedTimesheets" :key="timesheetItem.id" class="dib rejected-timesheet-item mb2 f6 mr2">
+              <inertia-link :href="timesheetItem.url">{{ timesheetItem.started_at }}</inertia-link>
             </li>
           </ul>
         </div>

--- a/resources/lang/en/app.php
+++ b/resources/lang/en/app.php
@@ -54,6 +54,7 @@ return [
     'hide_help' => 'Hide help',
 
     'breadcrumb_dashboard' => 'Home',
+    'breadcrumb_dashboard_hr' => 'Human Resources',
     'breadcrumb_dashboard_manager' => 'Manager',
     'breadcrumb_dashboard_manager_expense_details' => 'Expense details',
     'breadcrumb_account_home' => 'Account administration',
@@ -102,6 +103,7 @@ return [
     'breadcrumb_project_create_message' => 'Add a new message',
     'breadcrumb_project_edit_message' => 'Edit message',
     'breadcrumb_dashboard_one_on_one' => 'One on One',
+    'breadcrumb_dashboard_manager_timesheets' => 'All timesheets',
     'breadcrumb_team_list' => 'All teams',
     'breadcrumb_team_show_team_news' => 'Team news',
     'breadcrumb_team_add_team_news' => 'Add a team news',

--- a/resources/lang/en/app.php
+++ b/resources/lang/en/app.php
@@ -146,4 +146,6 @@ return [
     'rate_manager_bad' => 'Not ideal',
     'rate_manager_average' => 'It’s going well',
     'rate_manager_good' => 'Simply great',
+
+    'duration' => ':hours h :minutes',
 ];

--- a/resources/lang/en/dashboard.php
+++ b/resources/lang/en/dashboard.php
@@ -149,6 +149,8 @@ return [
     'manager_timesheet_approved' => 'The timesheet has been approved',
     'manager_timesheet_rejected' => 'The timesheet has been rejected',
     'manager_timesheet_view_details' => 'View details',
+    'manager_timesheet_summary_count' => 'You have {count} timesheets to approve.',
+    'manager_timesheet_index_title' => 'Timesheets of your direct reports to approve',
 
     'accounting_expense_detail_cta' => 'Accept or reject this expense',
     'accounting_expense_detail_expense_section' => 'Expense details',
@@ -222,4 +224,9 @@ return [
     'timesheet_create_project' => 'Create a project',
     'timesheet_create_choose_project' => 'Choose a project',
     'timesheet_create_choose_task' => 'Choose a task',
+
+    'hr_timesheets_title' => 'Timesheets',
+    'hr_timesheet_index_title' => 'All the timesheets that need approvals',
+    'hr_timesheet_summary_count' => '{count} timesheets to approve for employees who don’t have a manager',
+    'hr_timesheet_summary_blank' => 'There are no timesheets to approve for now.',
 ];

--- a/resources/lang/en/dashboard.php
+++ b/resources/lang/en/dashboard.php
@@ -5,8 +5,9 @@ return [
     'tab_my_team' => 'Your team',
     'tab_expenses' => 'Accountant area',
     'tab_manager' => 'Manager area',
+    'tab_hr' => 'HR area',
 
-    'blank_state' => 'You are not associated with a team at the moment.',
+    'dstate' => 'You are not associated with a team at the moment.',
 
     'morale_title' => 'How do you feel?',
     'morale_success_message' => 'Thanks for telling us how you feel.',
@@ -147,6 +148,7 @@ return [
     'manager_timesheet_approval_duration' => ':hours h :minutes',
     'manager_timesheet_approved' => 'The timesheet has been approved',
     'manager_timesheet_rejected' => 'The timesheet has been rejected',
+    'manager_timesheet_view_details' => 'View details',
 
     'accounting_expense_detail_cta' => 'Accept or reject this expense',
     'accounting_expense_detail_expense_section' => 'Expense details',

--- a/resources/lang/en/project.php
+++ b/resources/lang/en/project.php
@@ -125,4 +125,5 @@ return [
     'task_list_create_success' => 'The task list has been created.',
     'task_list_update_success' => 'The task list has been updated.',
     'task_list_destroy_success' => 'The task list has been deleted.',
+    'task_item_duration' => ':hours h :minutes',
 ];

--- a/routes/web.php
+++ b/routes/web.php
@@ -84,6 +84,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
             Route::get('manager/expenses/{expense}', 'Company\\Dashboard\\DashboardManagerController@showExpense')->name('dashboard.manager.expense.show');
             Route::post('manager/expenses/{expense}/accept', 'Company\\Dashboard\\DashboardManagerController@accept');
             Route::post('manager/expenses/{expense}/reject', 'Company\\Dashboard\\DashboardManagerController@reject');
+            Route::get('manager/timesheets/{timesheet}', 'Company\\Dashboard\\DashboardTimesheetManagerController@show')->name('dashboard.manager.timesheet.show');
             Route::post('manager/timesheets/{timesheet}/approve', 'Company\\Dashboard\\DashboardTimesheetManagerController@approve');
             Route::post('manager/timesheets/{timesheet}/reject', 'Company\\Dashboard\\DashboardTimesheetManagerController@reject');
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -61,9 +61,6 @@ Route::middleware(['auth', 'verified'])->group(function () {
             // company
             Route::get('company', 'Company\\Dashboard\\DashboardCompanyController@index')->name('dashboard.company');
 
-            // hr
-            Route::get('hr', 'Company\\Dashboard\\DashboardHRController@index')->name('dashboard.hr');
-
             // timesheet
             Route::get('timesheet/projects', 'Company\\Dashboard\\DashboardTimesheetController@projects')->name('dashboard.timesheet.projects');
             Route::get('timesheet/{timesheet}/projects/{project}/tasks', 'Company\\Dashboard\\DashboardTimesheetController@tasks')->name('dashboard.timesheet.projects');
@@ -78,19 +75,6 @@ Route::middleware(['auth', 'verified'])->group(function () {
             Route::get('team', 'Company\\Dashboard\\DashboardTeamController@index')->name('dashboard.team');
             Route::get('team/{team}', 'Company\\Dashboard\\DashboardTeamController@index');
             Route::get('team/{team}/{date}', 'Company\\Dashboard\\DashboardTeamController@worklogDetails');
-
-            // manager
-            Route::get('manager', 'Company\\Dashboard\\DashboardManagerController@index')->name('dashboard.manager');
-            Route::get('manager/expenses/{expense}', 'Company\\Dashboard\\DashboardManagerController@showExpense')->name('dashboard.manager.expense.show');
-            Route::post('manager/expenses/{expense}/accept', 'Company\\Dashboard\\DashboardManagerController@accept');
-            Route::post('manager/expenses/{expense}/reject', 'Company\\Dashboard\\DashboardManagerController@reject');
-            Route::get('manager/timesheets/{timesheet}', 'Company\\Dashboard\\DashboardTimesheetManagerController@show')->name('dashboard.manager.timesheet.show');
-            Route::post('manager/timesheets/{timesheet}/approve', 'Company\\Dashboard\\DashboardTimesheetManagerController@approve');
-            Route::post('manager/timesheets/{timesheet}/reject', 'Company\\Dashboard\\DashboardTimesheetManagerController@reject');
-
-            // rate your manager
-            Route::post('manager/rate/{answer}', 'Company\\Dashboard\\DashboardRateYourManagerController@store');
-            Route::post('manager/rate/{answer}/comment', 'Company\\Dashboard\\DashboardRateYourManagerController@storeComment');
 
             // details of one on ones
             Route::get('oneonones/{entry}', 'Company\\Dashboard\\DashboardMeOneOnOneController@show')->name('dashboard.oneonones.show');
@@ -109,6 +93,35 @@ Route::middleware(['auth', 'verified'])->group(function () {
             Route::post('oneonones/{entry}/notes', 'Company\\Dashboard\\DashboardMeOneOnOneController@storeNote');
             Route::post('oneonones/{entry}/notes/{note}', 'Company\\Dashboard\\DashboardMeOneOnOneController@updateNote');
             Route::delete('oneonones/{entry}/notes/{note}', 'Company\\Dashboard\\DashboardMeOneOnOneController@destroyNote');
+
+            // manager tab
+            Route::prefix('manager')->group(function () {
+                Route::get('', 'Company\\Dashboard\\DashboardManagerController@index')->name('dashboard.manager');
+                Route::get('expenses/{expense}', 'Company\\Dashboard\\DashboardManagerController@showExpense')->name('dashboard.manager.expense.show');
+                Route::post('expenses/{expense}/accept', 'Company\\Dashboard\\DashboardManagerController@accept');
+                Route::post('expenses/{expense}/reject', 'Company\\Dashboard\\DashboardManagerController@reject');
+
+                // timesheets
+                Route::get('timesheets', 'Company\\Dashboard\\DashboardManagerTimesheetController@index')->name('dashboard.manager.timesheet.index');
+                Route::get('timesheets/{timesheet}', 'Company\\Dashboard\\DashboardManagerTimesheetController@show')->name('dashboard.manager.timesheet.show');
+                Route::post('timesheets/{timesheet}/approve', 'Company\\Dashboard\\DashboardManagerTimesheetController@approve');
+                Route::post('timesheets/{timesheet}/reject', 'Company\\Dashboard\\DashboardManagerTimesheetController@reject');
+
+                // rate your manager
+                Route::post('rate/{answer}', 'Company\\Dashboard\\DashboardRateYourManagerController@store');
+                Route::post('rate/{answer}/comment', 'Company\\Dashboard\\DashboardRateYourManagerController@storeComment');
+            });
+
+            // hr tab
+            Route::prefix('hr')->group(function () {
+                Route::get('', 'Company\\Dashboard\\DashboardHRController@index')->name('dashboard.hr');
+
+                // timesheets
+                Route::get('timesheets', 'Company\\Dashboard\\DashboardHRTimesheetController@index')->name('dashboard.hr.timesheet.index');
+                Route::get('timesheets/{timesheet}', 'Company\\Dashboard\\DashboardHRTimesheetController@show')->name('dashboard.hr.timesheet.show');
+                Route::post('timesheets/{timesheet}/approve', 'Company\\Dashboard\\DashboardHRTimesheetController@approve');
+                Route::post('timesheets/{timesheet}/reject', 'Company\\Dashboard\\DashboardHRTimesheetController@reject');
+            });
         });
 
         Route::prefix('employees')->group(function () {

--- a/tests/Unit/Helpers/TimeHelperTest.php
+++ b/tests/Unit/Helpers/TimeHelperTest.php
@@ -37,4 +37,24 @@ class TimeHelperTest extends TestCase
             TimeHelper::convertToHoursAndMinutes(01)
         );
     }
+
+    /** @test */
+    public function it_gets_a_string_representing_a_given_duration(): void
+    {
+        $this->assertEquals(
+            '1h40',
+            TimeHelper::durationInHumanFormat([
+                'hours' => 1,
+                'minutes' => 40,
+            ])
+        );
+
+        $this->assertEquals(
+            '0h00',
+            TimeHelper::durationInHumanFormat([
+                'hours' => 0,
+                'minutes' => 00,
+            ])
+        );
+    }
 }

--- a/tests/Unit/ViewHelpers/Company/Project/ProjectTasksViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Company/Project/ProjectTasksViewHelperTest.php
@@ -43,6 +43,7 @@ class ProjectTasksViewHelperTest extends TestCase
                     'description' => $projectTaskA->description,
                     'completed' => true,
                     'completed_at' => 'Jan 01, 2018',
+                    'duration' => '0h00',
                     'author' => [
                         'id' => $michael->id,
                         'name' => $michael->name,
@@ -62,6 +63,7 @@ class ProjectTasksViewHelperTest extends TestCase
                     'description' => $projectTaskB->description,
                     'completed' => false,
                     'completed_at' => null,
+                    'duration' => '0h00',
                     'author' => null,
                     'assignee' => null,
                 ],
@@ -124,6 +126,7 @@ class ProjectTasksViewHelperTest extends TestCase
                     'description' => $projectTaskA->description,
                     'completed' => true,
                     'completed_at' => 'Jan 01, 2018',
+                    'duration' => '0h00',
                     'author' => [
                         'id' => $michael->id,
                         'name' => $michael->name,
@@ -163,6 +166,7 @@ class ProjectTasksViewHelperTest extends TestCase
                     'description' => $projectTaskB->description,
                     'completed' => false,
                     'completed_at' => null,
+                    'duration' => '0h00',
                     'author' => null,
                     'assignee' => null,
                 ],
@@ -178,6 +182,7 @@ class ProjectTasksViewHelperTest extends TestCase
                     'description' => $projectTaskC->description,
                     'completed' => false,
                     'completed_at' => null,
+                    'duration' => '0h00',
                     'author' => null,
                     'assignee' => null,
                 ],
@@ -210,6 +215,7 @@ class ProjectTasksViewHelperTest extends TestCase
                 'description' => $projectTaskA->description,
                 'completed' => true,
                 'completed_at' => 'Jan 01, 2018',
+                'duration' => '0h00',
                 'author' => [
                     'id' => $michael->id,
                     'name' => $michael->name,

--- a/tests/Unit/ViewHelpers/Dashboard/DashboardHRViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Dashboard/DashboardHRViewHelperTest.php
@@ -48,9 +48,9 @@ class DashboardHRViewHelperTest extends TestCase
             'status' => Timesheet::READY_TO_SUBMIT,
         ]);
 
-        $collection = DashboardHRViewHelper::employeesWithoutManagersWithPendingTimesheets($michael->company);
+        $array = DashboardHRViewHelper::employeesWithoutManagersWithPendingTimesheets($michael->company);
 
-        $this->assertEquals(1, $collection->count());
+        $this->assertEquals(1, $array['employees']->count());
 
         $this->assertEquals(
             [
@@ -60,7 +60,12 @@ class DashboardHRViewHelperTest extends TestCase
                     'avatar' => $michael->avatar,
                 ],
             ],
-            $collection->toArray()
+            $array['employees']->toArray()
+        );
+
+        $this->assertEquals(
+            env('APP_URL').'/'.$dwight->company_id.'/dashboard/hr/timesheets',
+            $array['url_view_all']
         );
     }
 
@@ -92,8 +97,6 @@ class DashboardHRViewHelperTest extends TestCase
         ]);
 
         $array = DashboardHRViewHelper::statisticsAboutTimesheets($company);
-
-        // $this->assertEquals(1, $collection->count());
 
         $this->assertEquals(
             [

--- a/tests/Unit/ViewHelpers/Dashboard/DashboardHRViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Dashboard/DashboardHRViewHelperTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Tests\Unit\ViewHelpers\Dashboard;
+
+use Carbon\Carbon;
+use Tests\TestCase;
+use App\Models\Company\Company;
+use App\Models\Company\Employee;
+use App\Models\Company\Timesheet;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use App\Services\Company\Employee\Manager\AssignManager;
+use App\Http\ViewHelpers\Dashboard\DashboardHRViewHelper;
+
+class DashboardHRViewHelperTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    /** @test */
+    public function it_gets_a_collection_of_employees_without_managers_who_have_pending_timesheets(): void
+    {
+        Carbon::setTestNow(Carbon::create(2018, 1, 1));
+        $michael = $this->createAdministrator();
+        $dwight = Employee::factory()->create([
+            'company_id' => $michael->company_id,
+        ]);
+
+        // michael will be direct report of dwight
+        (new AssignManager)->execute([
+            'company_id' => $michael->company_id,
+            'author_id' => $michael->id,
+            'employee_id' => $dwight->id,
+            'manager_id' => $michael->id,
+        ]);
+
+        // michael has one unapproved timesheets
+        Timesheet::factory()->create([
+            'company_id' => $michael->company_id,
+            'employee_id' => $michael->id,
+            'started_at' => '2017-12-25 00:00:00',
+            'status' => Timesheet::READY_TO_SUBMIT,
+        ]);
+
+        // dwight has one unapproved timesheets, but it shouldn't appear in the collection as he has a manager
+        Timesheet::factory()->create([
+            'company_id' => $michael->company_id,
+            'employee_id' => $dwight->id,
+            'started_at' => '2017-12-25 00:00:00',
+            'status' => Timesheet::READY_TO_SUBMIT,
+        ]);
+
+        $collection = DashboardHRViewHelper::employeesWithoutManagersWithPendingTimesheets($michael->company);
+
+        $this->assertEquals(1, $collection->count());
+
+        $this->assertEquals(
+            [
+                0 => [
+                    'id' => $michael->id,
+                    'name' => $michael->name,
+                    'avatar' => $michael->avatar,
+                ],
+            ],
+            $collection->toArray()
+        );
+    }
+
+    /** @test */
+    public function it_gets_a_collection_of_statistics_about_timesheets(): void
+    {
+        Carbon::setTestNow(Carbon::create(2018, 1, 1));
+
+        $company = Company::factory()->create();
+
+        // we'll have
+        // - 2 timesheets in a ready to submit state
+        // - 2 timesheets in a rejected state
+        // - 2 timesheets in a accepted state
+        Timesheet::factory()->count(2)->create([
+            'company_id' => $company->id,
+            'started_at' => '2017-12-25 00:00:00',
+            'status' => Timesheet::READY_TO_SUBMIT,
+        ]);
+        Timesheet::factory()->count(2)->create([
+            'company_id' => $company->id,
+            'started_at' => '2017-12-25 00:00:00',
+            'status' => Timesheet::REJECTED,
+        ]);
+        Timesheet::factory()->count(2)->create([
+            'company_id' => $company->id,
+            'started_at' => '2017-12-25 00:00:00',
+            'status' => Timesheet::APPROVED,
+        ]);
+
+        $array = DashboardHRViewHelper::statisticsAboutTimesheets($company);
+
+        // $this->assertEquals(1, $collection->count());
+
+        $this->assertEquals(
+            [
+                'total' => 6,
+                'rejected' => 2,
+            ],
+            $array
+        );
+    }
+}

--- a/tests/Unit/ViewHelpers/Dashboard/DashboardManagerViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Dashboard/DashboardManagerViewHelperTest.php
@@ -323,6 +323,7 @@ class DashboardManagerViewHelperTest extends TestCase
                     'started_at' => 'Jan 01, 2018',
                     'ended_at' => 'Jan 07, 2018',
                     'duration' => '01 h 40',
+                    'url' => env('APP_URL').'/'.$michael->company_id.'/dashboard/manager/timesheets/'.$timesheetA->id,
                 ],
             ],
             $collection->toArray()[0]['timesheets']->toArray()

--- a/tests/Unit/ViewHelpers/Dashboard/DashboardManagerViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Dashboard/DashboardManagerViewHelperTest.php
@@ -227,7 +227,7 @@ class DashboardManagerViewHelperTest extends TestCase
     }
 
     /** @test */
-    public function it_gets_a_collection_of_employees_who_have_timesheets_to_approve(): void
+    public function it_gets_an_array_of_data_about_employees_who_have_timesheets_to_approve(): void
     {
         Carbon::setTestNow(Carbon::create(2018, 1, 1));
         $michael = $this->createAdministrator();
@@ -277,56 +277,27 @@ class DashboardManagerViewHelperTest extends TestCase
             'project_task_id' => $task->id,
         ]);
 
-        $collection = DashboardManagerViewHelper::timesheetApprovals($michael, $michael->directReports);
+        $array = DashboardManagerViewHelper::employeesWithTimesheetsToApprove($michael, $michael->directReports);
 
         // make sure there is only one employee
         $this->assertEquals(
             1,
-            $collection->count()
+            $array['totalNumberOfTimesheetsToValidate']
+        );
+
+        $this->assertEquals(
+            env('APP_URL').'/'.$dwight->company_id.'/dashboard/manager/timesheets',
+            $array['url_view_all']
         );
 
         // now analyzing what's returned from the method
         $this->assertEquals(
             $dwight->id,
-            $collection->toArray()[0]['id']
-        );
-        $this->assertEquals(
-            'Dwight Schrute',
-            $collection->toArray()[0]['name']
-        );
-        $this->assertEquals(
-            $dwight->avatar,
-            $collection->toArray()[0]['avatar']
-        );
-        $this->assertEquals(
-            $dwight->position->title,
-            $collection->toArray()[0]['position']
+            $array['employees']->toArray()[0]['id']
         );
         $this->assertEquals(
             env('APP_URL').'/'.$dwight->company_id.'/employees/'.$dwight->id,
-            $collection->toArray()[0]['url']
-        );
-        $this->assertEquals(
-            env('APP_URL').'/'.$dwight->company_id.'/employees/'.$dwight->id,
-            $collection->toArray()[0]['url']
-        );
-
-        // analyzing timesheets - there should be only one timesheet
-        $this->assertEquals(
-            1,
-            $collection->toArray()[0]['timesheets']->count()
-        );
-        $this->assertEquals(
-            [
-                0 => [
-                    'id' => $timesheetA->id,
-                    'started_at' => 'Jan 01, 2018',
-                    'ended_at' => 'Jan 07, 2018',
-                    'duration' => '01 h 40',
-                    'url' => env('APP_URL').'/'.$michael->company_id.'/dashboard/manager/timesheets/'.$timesheetA->id,
-                ],
-            ],
-            $collection->toArray()[0]['timesheets']->toArray()
+            $array['employees']->toArray()[0]['url']
         );
     }
 }

--- a/tests/Unit/ViewHelpers/Dashboard/HR/DashboardHRTimesheetViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Dashboard/HR/DashboardHRTimesheetViewHelperTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Tests\Unit\ViewHelpers\Dashboard\Manager;
+
+use Carbon\Carbon;
+use Tests\TestCase;
+use App\Models\Company\Project;
+use App\Models\Company\Employee;
+use App\Models\Company\Timesheet;
+use App\Models\Company\ProjectTask;
+use App\Models\Company\TimeTrackingEntry;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use App\Services\Company\Employee\Manager\AssignManager;
+use App\Http\ViewHelpers\Dashboard\HR\DashboardHRTimesheetViewHelper;
+
+class DashboardHRTimesheetViewHelperTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    /** @test */
+    public function it_gets_a_collection_of_employees_who_have_timesheets_to_approve(): void
+    {
+        Carbon::setTestNow(Carbon::create(2018, 1, 1));
+        $michael = $this->createAdministrator();
+
+        // creating two employees and adding timesheets after this
+        $dwight = factory(Employee::class)->create([
+            'company_id' => $michael->company_id,
+        ]);
+        $jim = factory(Employee::class)->create([
+            'company_id' => $michael->company_id,
+        ]);
+
+        (new AssignManager)->execute([
+            'company_id' => $michael->company_id,
+            'author_id' => $michael->id,
+            'employee_id' => $dwight->id,
+            'manager_id' => $michael->id,
+        ]);
+
+        // creating one timesheet ready to submit for dwight
+        $project = Project::factory()->create();
+        $task = ProjectTask::factory()->create([
+            'project_id' => $project->id,
+        ]);
+        $timesheetA = Timesheet::factory()->create([
+            'company_id' => $dwight->company_id,
+            'employee_id' => $dwight->id,
+            'status' => Timesheet::READY_TO_SUBMIT,
+            'started_at' => '2017-12-25 00:00:00',
+        ]);
+
+        // creating one timesheet for jim
+        $timesheetB = Timesheet::factory()->create([
+            'company_id' => $dwight->company_id,
+            'employee_id' => $jim->id,
+            'status' => Timesheet::READY_TO_SUBMIT,
+            'started_at' => '2017-12-25 00:00:00',
+        ]);
+        TimeTrackingEntry::factory()->create([
+            'timesheet_id' => $timesheetB->id,
+            'project_task_id' => $task->id,
+        ]);
+
+        $collection = DashboardHRTimesheetViewHelper::timesheetApprovalsForEmployeesWithoutManagers($michael->company);
+
+        // make sure there is only one employee
+        $this->assertEquals(
+            1,
+            $collection->count()
+        );
+
+        // now analyzing what's returned from the method
+        $this->assertEquals(
+            $jim->id,
+            $collection->toArray()[0]['id']
+        );
+        $this->assertEquals(
+            'Dwight Schrute',
+            $collection->toArray()[0]['name']
+        );
+        $this->assertEquals(
+            $jim->avatar,
+            $collection->toArray()[0]['avatar']
+        );
+        $this->assertEquals(
+            $jim->position->title,
+            $collection->toArray()[0]['position']
+        );
+        $this->assertEquals(
+            env('APP_URL').'/'.$jim->company_id.'/employees/'.$jim->id,
+            $collection->toArray()[0]['url']
+        );
+
+        // analyzing timesheets - there should be only one timesheet
+        $this->assertEquals(
+            1,
+            $collection->toArray()[0]['timesheets']->count()
+        );
+
+        $this->assertEquals(
+            [
+                0 => [
+                    'id' => $timesheetB->id,
+                    'started_at' => 'Dec 25, 2017',
+                    'ended_at' => 'Jan 07, 2018',
+                    'duration' => '01 h 40',
+                    'url' => env('APP_URL').'/'.$michael->company_id.'/dashboard/hr/timesheets/'.$timesheetB->id,
+                ],
+            ],
+            $collection->toArray()[0]['timesheets']->toArray()
+        );
+    }
+}

--- a/tests/Unit/ViewHelpers/Dashboard/Manager/DashboardManagerTimesheetViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Dashboard/Manager/DashboardManagerTimesheetViewHelperTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Tests\Unit\ViewHelpers\Dashboard\Manager;
+
+use Carbon\Carbon;
+use Tests\TestCase;
+use App\Models\Company\Project;
+use App\Models\Company\Employee;
+use App\Models\Company\Timesheet;
+use App\Models\Company\ProjectTask;
+use App\Models\Company\TimeTrackingEntry;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use App\Services\Company\Employee\Manager\AssignManager;
+use App\Http\ViewHelpers\Dashboard\Manager\DashboardManagerTimesheetViewHelper;
+
+class DashboardManagerTimesheetViewHelperTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    /** @test */
+    public function it_gets_a_collection_of_employees_who_have_timesheets_to_approve(): void
+    {
+        Carbon::setTestNow(Carbon::create(2018, 1, 1));
+        $michael = $this->createAdministrator();
+
+        // creating two employees and adding timesheets after this
+        $dwight = factory(Employee::class)->create([
+            'company_id' => $michael->company_id,
+        ]);
+        $jim = factory(Employee::class)->create([
+            'company_id' => $michael->company_id,
+        ]);
+
+        (new AssignManager)->execute([
+            'company_id' => $michael->company_id,
+            'author_id' => $michael->id,
+            'employee_id' => $dwight->id,
+            'manager_id' => $michael->id,
+        ]);
+        (new AssignManager)->execute([
+            'company_id' => $michael->company_id,
+            'author_id' => $michael->id,
+            'employee_id' => $jim->id,
+            'manager_id' => $michael->id,
+        ]);
+
+        // creating one timesheet ready to submit
+        $project = Project::factory()->create();
+        $task = ProjectTask::factory()->create([
+            'project_id' => $project->id,
+        ]);
+        $timesheetA = Timesheet::factory()->create([
+            'employee_id' => $dwight->id,
+            'status' => Timesheet::READY_TO_SUBMIT,
+        ]);
+        TimeTrackingEntry::factory()->create([
+            'timesheet_id' => $timesheetA->id,
+            'project_task_id' => $task->id,
+        ]);
+
+        // creating one timesheet but not ready - it shouldn't appear in the
+        // collection
+        $timesheetB = Timesheet::factory()->create([
+            'employee_id' => $dwight->id,
+        ]);
+        TimeTrackingEntry::factory()->create([
+            'timesheet_id' => $timesheetB->id,
+            'project_task_id' => $task->id,
+        ]);
+
+        $collection = DashboardManagerTimesheetViewHelper::timesheetApprovals($michael, $michael->directReports);
+
+        // make sure there is only one employee
+        $this->assertEquals(
+            1,
+            $collection->count()
+        );
+
+        // now analyzing what's returned from the method
+        $this->assertEquals(
+            $dwight->id,
+            $collection->toArray()[0]['id']
+        );
+        $this->assertEquals(
+            'Dwight Schrute',
+            $collection->toArray()[0]['name']
+        );
+        $this->assertEquals(
+            $dwight->avatar,
+            $collection->toArray()[0]['avatar']
+        );
+        $this->assertEquals(
+            $dwight->position->title,
+            $collection->toArray()[0]['position']
+        );
+        $this->assertEquals(
+            env('APP_URL').'/'.$dwight->company_id.'/employees/'.$dwight->id,
+            $collection->toArray()[0]['url']
+        );
+        $this->assertEquals(
+            env('APP_URL').'/'.$dwight->company_id.'/employees/'.$dwight->id,
+            $collection->toArray()[0]['url']
+        );
+
+        // analyzing timesheets - there should be only one timesheet
+        $this->assertEquals(
+            1,
+            $collection->toArray()[0]['timesheets']->count()
+        );
+        $this->assertEquals(
+            [
+                0 => [
+                    'id' => $timesheetA->id,
+                    'started_at' => 'Jan 01, 2018',
+                    'ended_at' => 'Jan 07, 2018',
+                    'duration' => '01 h 40',
+                    'url' => env('APP_URL').'/'.$michael->company_id.'/dashboard/manager/timesheets/'.$timesheetA->id,
+                ],
+            ],
+            $collection->toArray()[0]['timesheets']->toArray()
+        );
+    }
+}

--- a/tests/Unit/ViewHelpers/Team/TeamRecentShipViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Team/TeamRecentShipViewHelperTest.php
@@ -35,6 +35,17 @@ class TeamRecentShipViewHelperTest extends TestCase
         $this->assertEquals(
             [
                 0 => [
+                    'id' => $featureB->id,
+                    'title' => $featureB->title,
+                    'description' => $featureB->description,
+                    'employees' => null,
+                    'url' => route('ships.show', [
+                        'company' => $featureB->team->company,
+                        'team' => $featureB->team,
+                        'ship' => $featureB->id,
+                    ]),
+                ],
+                1 => [
                     'id' => $featureA->id,
                     'title' => $featureA->title,
                     'description' => $featureA->description,
@@ -50,17 +61,6 @@ class TeamRecentShipViewHelperTest extends TestCase
                         'company' => $featureA->team->company,
                         'team' => $featureA->team,
                         'ship' => $featureA->id,
-                    ]),
-                ],
-                1 => [
-                    'id' => $featureB->id,
-                    'title' => $featureB->title,
-                    'description' => $featureB->description,
-                    'employees' => null,
-                    'url' => route('ships.show', [
-                        'company' => $featureB->team->company,
-                        'team' => $featureB->team,
-                        'ship' => $featureB->id,
                     ]),
                 ],
             ],


### PR DESCRIPTION
So, this PR adds a dashboard for HR for the timesheets specifically. On this screen, HR people get to accept or reject timesheets for employees who don’t have a manager.

It also fixes a bunch of bugs regarding timesheets.

Empty state:
<img width="871" alt="image" src="https://user-images.githubusercontent.com/61099/105593787-fbf03880-5d60-11eb-96aa-cdb5c6a463f0.png">

Not empty state:
<img width="831" alt="image" src="https://user-images.githubusercontent.com/61099/105613547-307be880-5d91-11eb-856c-8acb8741b041.png">

List:
<img width="832" alt="image" src="https://user-images.githubusercontent.com/61099/105613601-85b7fa00-5d91-11eb-9b80-6688876cab2c.png">



You fool, don't forget these steps:

- [x] Unit tests
- [ ] Tests with Cypress
- [ ] Documentation
- [ ] Dummy data
