### PR TITLE
feat(workfromhome): show who work from home in team page

### DIFF
--- a/app/Http/ViewHelpers/Team/TeamMembersViewHelper.php
+++ b/app/Http/ViewHelpers/Team/TeamMembersViewHelper.php
@@ -2,10 +2,10 @@
 
 namespace App\Http\ViewHelpers\Team;
 
+use Carbon\Carbon;
 use App\Helpers\ImageHelper;
 use App\Models\Company\Team;
 use App\Models\Company\Company;
-use Carbon\Carbon;
 use App\Models\Company\Employee;
 use Illuminate\Support\Collection;
 use App\Helpers\WorkFromHomeHelper;

--- a/app/Http/ViewHelpers/Team/TeamMembersViewHelper.php
+++ b/app/Http/ViewHelpers/Team/TeamMembersViewHelper.php
@@ -5,8 +5,10 @@ namespace App\Http\ViewHelpers\Team;
 use App\Helpers\ImageHelper;
 use App\Models\Company\Team;
 use App\Models\Company\Company;
+use Carbon\Carbon;
 use App\Models\Company\Employee;
 use Illuminate\Support\Collection;
+use App\Helpers\WorkFromHomeHelper;
 
 class TeamMembersViewHelper
 {
@@ -63,6 +65,7 @@ class TeamMembersViewHelper
             'name' => $employee->name,
             'avatar' => ImageHelper::getAvatar($employee, 35),
             'position' => $employee->position,
+            'workFromHome' => WorkFromHomeHelper::hasWorkedFromHomeOnDate($employee, Carbon::now()),
         ];
     }
 }

--- a/app/Http/ViewHelpers/Team/TeamShowViewHelper.php
+++ b/app/Http/ViewHelpers/Team/TeamShowViewHelper.php
@@ -3,13 +3,12 @@
 namespace App\Http\ViewHelpers\Team;
 
 use Carbon\Carbon;
-use App\Helpers\DateHelper;
-use App\Helpers\ImageHelper;
 use App\Models\Company\Team;
 use App\Helpers\StringHelper;
 use App\Helpers\BirthdayHelper;
 use App\Models\Company\Company;
 use Illuminate\Support\Collection;
+use App\Helpers\WorkFromHomeHelper;
 
 class TeamShowViewHelper
 {
@@ -55,6 +54,8 @@ class TeamShowViewHelper
             ->get();
 
         $employeesCollection = collect([]);
+        $now = Carbon::now();
+
         foreach ($employees as $employee) {
             $employeesCollection->push([
                 'id' => $employee->id,
@@ -64,6 +65,7 @@ class TeamShowViewHelper
                     'id' => $employee->position->id,
                     'title' => $employee->position->title,
                 ],
+                'workFromHome' => WorkFromHomeHelper::hasWorkedFromHomeOnDate($employee, $now),
                 'url' => route('employees.show', [
                     'company' => $employee->company,
                     'employee' => $employee,

--- a/app/Http/ViewHelpers/Team/TeamShowViewHelper.php
+++ b/app/Http/ViewHelpers/Team/TeamShowViewHelper.php
@@ -3,6 +3,8 @@
 namespace App\Http\ViewHelpers\Team;
 
 use Carbon\Carbon;
+use App\Helpers\DateHelper;
+use App\Helpers\ImageHelper;
 use App\Models\Company\Team;
 use App\Helpers\StringHelper;
 use App\Helpers\BirthdayHelper;

--- a/resources/js/Pages/Team/Partials/Members.vue
+++ b/resources/js/Pages/Team/Partials/Members.vue
@@ -101,6 +101,10 @@
         <p class="mv0">{{ $t('team.members_blank') }}</p>
       </div>
     </div>
+
+    <work-from-home
+      :work-from-homes="listOfEmployees.filter(employee => employee.workFromHome)"
+    />
   </div>
 </template>
 
@@ -109,12 +113,14 @@ import TextInput from '@/Shared/TextInput';
 import Avatar from '@/Shared/Avatar';
 import 'vue-loaders/dist/vue-loaders.css';
 import BallPulseLoader from 'vue-loaders/dist/loaders/ball-pulse';
+import WorkFromHome from '@/Pages/Team/Partials/WorkFromHome';
 
 export default {
   components: {
     TextInput,
     Avatar,
     'ball-pulse-loader': BallPulseLoader.component,
+    WorkFromHome,
   },
 
   props: {

--- a/resources/js/Pages/Team/Partials/WorkFromHome.vue
+++ b/resources/js/Pages/Team/Partials/WorkFromHome.vue
@@ -1,0 +1,64 @@
+<style lang="scss" scoped>
+.avatar {
+  left: 1px;
+  top: 5px;
+  width: 35px;
+}
+
+.team-member {
+  padding-left: 44px;
+
+  .avatar {
+    top: 2px;
+  }
+}
+</style>
+
+<template>
+  <div>
+    <!-- case of no one working from home -->
+    <h4 v-show="workFromHomes.length == 0" class="db fw5 mb3 flex justify-between items-center">
+      {{ $t('dashboard.team_work_from_home_blank') }}
+    </h4>
+
+    <div v-show="workFromHomes.length != 0">
+      <h3 class="db fw5 mb3 flex justify-between items-center">
+        🏡 {{ $t('dashboard.team_work_from_home_title') }}
+      </h3>
+
+      <div class="mb4 bg-white box cf">
+        <!-- all people working from homes -->
+        <div v-for="employee in workFromHomes" :key="employee.id" class="pa3 fl w-third-l w-100" data-cy="work-from-home-list">
+          <span class="pl3 db relative team-member">
+            <img loading="lazy" :src="employee.avatar" class="br-100 absolute avatar" alt="avatar" />
+
+            <!-- normal mode -->
+            <inertia-link :href="employee.url" class="mb2">
+              {{ employee.name }}
+            </inertia-link>
+
+            <!-- position -->
+            <span v-if="employee.position" class="title db f7 mt1">
+              {{ employee.position.title }}
+            </span>
+            <span v-else class="title db f7 mt1">
+              {{ $t('app.no_position_defined') }}
+            </span>
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+
+export default {
+  props: {
+    workFromHomes: {
+      type: Array,
+      default: () => [],
+    },
+  },
+};
+</script>

--- a/tests/Unit/ViewHelpers/Team/TeamMembersViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Team/TeamMembersViewHelperTest.php
@@ -2,10 +2,12 @@
 
 namespace Tests\Unit\ViewHelpers\Team;
 
+use Carbon\Carbon;
 use Tests\TestCase;
 use App\Helpers\ImageHelper;
 use App\Models\Company\Team;
 use App\Models\Company\Employee;
+use App\Models\Company\WorkFromHome;
 use App\Http\ViewHelpers\Team\TeamMembersViewHelper;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use App\Services\Company\Employee\Team\AddEmployeeToTeam;
@@ -62,7 +64,7 @@ class TeamMembersViewHelperTest extends TestCase
 
         $array = TeamMembersViewHelper::employee($michael);
 
-        $this->assertEquals(4, count($array));
+        $this->assertEquals(5, count($array));
 
         $this->assertEquals(
             [
@@ -70,6 +72,34 @@ class TeamMembersViewHelperTest extends TestCase
                 'name' => $michael->name,
                 'avatar' => ImageHelper::getAvatar($michael, 35),
                 'position' => $michael->position,
+                'workFromHome' => false,
+            ],
+            $array
+        );
+    }
+
+    /** @test */
+    public function it_gets_an_array_containing_information_about_the_employee_work_from_home_today(): void
+    {
+        $michael = $this->createAdministrator();
+
+        // add work from home status on today
+        factory(WorkFromHome::class)->create([
+            'employee_id' => $michael->id,
+            'date' => Carbon::now()->format('Y-m-d 00:00:00'),
+        ]);
+
+        $array = TeamMembersViewHelper::employee($michael);
+
+        $this->assertEquals(5, count($array));
+
+        $this->assertEquals(
+            [
+                'id' => $michael->id,
+                'name' => $michael->name,
+                'avatar' => $michael->avatar,
+                'position' => $michael->position,
+                'workFromHome' => true,
             ],
             $array
         );

--- a/tests/Unit/ViewHelpers/Team/TeamMembersViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Team/TeamMembersViewHelperTest.php
@@ -84,7 +84,7 @@ class TeamMembersViewHelperTest extends TestCase
         $michael = $this->createAdministrator();
 
         // add work from home status on today
-        factory(WorkFromHome::class)->create([
+        WorkFromHome::factory()->create([
             'employee_id' => $michael->id,
             'date' => Carbon::now()->format('Y-m-d 00:00:00'),
         ]);

--- a/tests/Unit/ViewHelpers/Team/TeamMembersViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Team/TeamMembersViewHelperTest.php
@@ -97,7 +97,7 @@ class TeamMembersViewHelperTest extends TestCase
             [
                 'id' => $michael->id,
                 'name' => $michael->name,
-                'avatar' => $michael->avatar,
+                'avatar' => ImageHelper::getAvatar($michael, 35),
                 'position' => $michael->position,
                 'workFromHome' => true,
             ],

--- a/tests/Unit/ViewHelpers/Team/TeamShowViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Team/TeamShowViewHelperTest.php
@@ -8,6 +8,7 @@ use App\Helpers\ImageHelper;
 use App\Models\Company\Ship;
 use App\Models\Company\Team;
 use App\Models\Company\Employee;
+use App\Models\Company\WorkFromHome;
 use App\Http\ViewHelpers\Team\TeamShowViewHelper;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 
@@ -31,6 +32,12 @@ class TeamShowViewHelperTest extends TestCase
             'company_id' => $michael->company_id,
         ]);
 
+        // create one employee work from home on today
+        factory(WorkFromHome::class)->create([
+            'employee_id' => $michael->id,
+            'date' => Carbon::now()->format('Y-m-d 00:00:00'),
+        ]);
+
         $team->employees()->attach([$michael->id]);
         $team->employees()->attach([$dwight->id]);
 
@@ -49,6 +56,7 @@ class TeamShowViewHelperTest extends TestCase
                         'title' => $michael->position->title,
                     ],
                     'url' => env('APP_URL').'/'.$michael->company_id.'/employees/'.$michael->id,
+                    'workFromHome' => true,
                 ],
                 1 => [
                     'id' => $dwight->id,
@@ -59,6 +67,7 @@ class TeamShowViewHelperTest extends TestCase
                         'title' => $dwight->position->title,
                     ],
                     'url' => env('APP_URL').'/'.$dwight->company_id.'/employees/'.$dwight->id,
+                    'workFromHome' => false,
                 ],
             ],
             $collection->toArray()

--- a/tests/Unit/ViewHelpers/Team/TeamShowViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Team/TeamShowViewHelperTest.php
@@ -33,7 +33,7 @@ class TeamShowViewHelperTest extends TestCase
         ]);
 
         // create one employee work from home on today
-        factory(WorkFromHome::class)->create([
+        WorkFromHome::factory()->create([
             'employee_id' => $michael->id,
             'date' => Carbon::now()->format('Y-m-d 00:00:00'),
         ]);


### PR DESCRIPTION
I found this task in TODO, my implementation:
When there are workfromhome:
<img width="705" alt="Screen Shot 2021-02-21 at 4 23 45 pm" src="https://user-images.githubusercontent.com/12780733/108622195-b9a63e00-7469-11eb-82cc-8bd208fead97.png">

No work from home:
<img width="747" alt="Screen Shot 2021-02-21 at 4 24 03 pm" src="https://user-images.githubusercontent.com/12780733/108622214-d0e52b80-7469-11eb-9376-dd0a5c1286c9.png">

But I feel it take lot of space when there are many members, so I think it should only show the number of `workfromhome` and a button, as below: 
<img width="747" alt="Screen Shot 2021-02-21 at 4 34 41 pm" src="https://user-images.githubusercontent.com/12780733/108622463-9bd9d880-746b-11eb-9741-7f7973e2dac1.png">


When users click on the button, it will filter `workFromHome` from `listOfEmployee` to display. 
In case, user click on `add/remove member`, the full `listOfEmployee` will be display again and `workfromhome` button will change back. So which one you think better?

You fool, don't forget these steps:

- [x] Unit tests
- [x] Tests with Cypress
- [ ] Documentation
- [ ] Dummy data
