### PR TITLE
feat: support of retina avatars

### DIFF
--- a/app/Helpers/ImageHelper.php
+++ b/app/Helpers/ImageHelper.php
@@ -12,21 +12,29 @@ class ImageHelper
      *
      * @param Employee $employee
      * @param int $width
-     * @return string|null
+     * @return array|null
      */
-    public static function getAvatar(Employee $employee, int $width = null): ?string
+    public static function getAvatar(Employee $employee, int $width = 64): ?array
     {
         if (! $employee->avatar_file_id) {
-            return 'https://ui-avatars.com/api/?name='.$employee->name;
+            return [
+                'normal' => 'https://ui-avatars.com/api/?name='.$employee->name.'&size='.$width,
+                'retina' => 'https://ui-avatars.com/api/?name='.$employee->name.'&size='.($width * 2),
+            ];
         }
 
         if ($width) {
             $url = $employee->picture->cdn_url.'-/scale_crop/'.$width.'x'.$width.'/smart/';
+            $url2x = $employee->picture->cdn_url.'-/scale_crop/'.($width * 2).'x'.($width * 2).'/smart/';
         } else {
             $url = $employee->picture->cdn_url;
+            $url2x = $employee->picture->cdn_url;
         }
 
-        return $url;
+        return [
+            'normal' => $url,
+            'retina' => $url2x,
+        ];
     }
 
     /**

--- a/app/Http/Controllers/Company/Adminland/AdminExpenseController.php
+++ b/app/Http/Controllers/Company/Adminland/AdminExpenseController.php
@@ -145,7 +145,7 @@ class AdminExpenseController extends Controller
             $employees->push([
                 'id' => $employee->id,
                 'name' => $employee->name,
-                'avatar' => ImageHelper::getAvatar($employee),
+                'avatar' => ImageHelper::getAvatar($employee, 23),
             ]);
         }
 
@@ -178,7 +178,7 @@ class AdminExpenseController extends Controller
             'data' => [
                 'id' => $employee->id,
                 'name' => $employee->name,
-                'avatar' => ImageHelper::getAvatar($employee),
+                'avatar' => ImageHelper::getAvatar($employee, 23),
                 'url' => route('employees.show', [
                     'company' => $loggedCompany,
                     'employee' => $employee,

--- a/app/Http/Controllers/Company/Adminland/AdminHardwareController.php
+++ b/app/Http/Controllers/Company/Adminland/AdminHardwareController.php
@@ -118,7 +118,7 @@ class AdminHardwareController extends Controller
             'employee' => $hardware->employee ? [
                 'id' => $hardware->employee->id,
                 'name' => $hardware->employee->name,
-                'avatar' => ImageHelper::getAvatar($hardware->employee),
+                'avatar' => ImageHelper::getAvatar($hardware->employee, 22),
             ] : null,
         ];
 

--- a/app/Http/Controllers/Company/Employee/EmployeeLogsController.php
+++ b/app/Http/Controllers/Company/Employee/EmployeeLogsController.php
@@ -50,7 +50,7 @@ class EmployeeLogsController extends Controller
         $logsCollection = EmployeeLogViewHelper::list($logs, $employee->company);
 
         return Inertia::render('Employee/Logs/Index', [
-            'employee' => $employee->toObject(),
+            'employee' => EmployeeLogViewHelper::employee($employee),
             'logs' => $logsCollection,
             'notifications' => NotificationHelper::getNotifications(InstanceHelper::getLoggedEmployee()),
             'paginator' => PaginatorHelper::getData($logs),

--- a/app/Http/ViewHelpers/Adminland/AdminExpenseViewHelper.php
+++ b/app/Http/ViewHelpers/Adminland/AdminExpenseViewHelper.php
@@ -47,7 +47,7 @@ class AdminExpenseViewHelper
             $employeesCollection->push([
                 'id' => $employee->id,
                 'name' => $employee->name,
-                'avatar' => ImageHelper::getAvatar($employee),
+                'avatar' => ImageHelper::getAvatar($employee, 23),
                 'url' => route('employees.show', [
                     'company' => $company,
                     'employee' => $employee,

--- a/app/Http/ViewHelpers/Adminland/AdminHardwareViewHelper.php
+++ b/app/Http/ViewHelpers/Adminland/AdminHardwareViewHelper.php
@@ -37,7 +37,7 @@ class AdminHardwareViewHelper
                 'employee' => ($employee) ? [
                     'id' => $employee->id,
                     'name' => $employee->name,
-                    'avatar' => ImageHelper::getAvatar($employee),
+                    'avatar' => ImageHelper::getAvatar($employee, 18),
                 ] : null,
             ]);
         }
@@ -104,7 +104,7 @@ class AdminHardwareViewHelper
                 'employee' => ($employee) ? [
                     'id' => $employee->id,
                     'name' => $employee->name,
-                    'avatar' => ImageHelper::getAvatar($employee),
+                    'avatar' => ImageHelper::getAvatar($employee, 18),
                 ] : null,
             ]);
         }
@@ -151,7 +151,7 @@ class AdminHardwareViewHelper
                 'employee' => ($employee) ? [
                     'id' => $employee->id,
                     'name' => $employee->name,
-                    'avatar' => ImageHelper::getAvatar($employee),
+                    'avatar' => ImageHelper::getAvatar($employee, 18),
                 ] : null,
             ]);
         }

--- a/app/Http/ViewHelpers/Company/Project/ProjectDecisionsViewHelper.php
+++ b/app/Http/ViewHelpers/Company/Project/ProjectDecisionsViewHelper.php
@@ -20,6 +20,7 @@ class ProjectDecisionsViewHelper
         $company = $project->company;
         $decisions = $project->decisions()
             ->with('deciders')
+            ->with('deciders.picture')
             ->latest()
             ->get();
 

--- a/app/Http/ViewHelpers/Company/Project/ProjectTasksViewHelper.php
+++ b/app/Http/ViewHelpers/Company/Project/ProjectTasksViewHelper.php
@@ -215,7 +215,7 @@ class ProjectTasksViewHelper
             'assignee' => $assignee ? [
                 'id' => $assignee->id,
                 'name' => $assignee->name,
-                'avatar' => ImageHelper::getAvatar($assignee),
+                'avatar' => ImageHelper::getAvatar($assignee, 35),
                 'url' => route('employees.show', [
                     'company' => $company,
                     'employee' => $assignee,

--- a/app/Http/ViewHelpers/Dashboard/Manager/DashboardManagerTimesheetViewHelper.php
+++ b/app/Http/ViewHelpers/Dashboard/Manager/DashboardManagerTimesheetViewHelper.php
@@ -59,7 +59,7 @@ class DashboardManagerTimesheetViewHelper
                 $employeesCollection->push([
                     'id' => $employee->id,
                     'name' => $employee->name,
-                    'avatar' => ImageHelper::getAvatar($employee),
+                    'avatar' => ImageHelper::getAvatar($employee, 35),
                     'position' => (! $employee->position) ? null : $employee->position->title,
                     'url' => route('employees.show', [
                         'company' => $company,

--- a/app/Http/ViewHelpers/Employee/EmployeeLogViewHelper.php
+++ b/app/Http/ViewHelpers/Employee/EmployeeLogViewHelper.php
@@ -24,7 +24,7 @@ class EmployeeLogViewHelper
                 'author' => [
                     'id' => is_null($author) ? null : $author->id,
                     'name' => is_null($author) ? $log->author_name : $author->name,
-                    'avatar' => is_null($author) ? null : ImageHelper::getAvatar($author),
+                    'avatar' => is_null($author) ? null : ImageHelper::getAvatar($author, 34),
                     'url' => is_null($author) ? null : route('employees.show', [
                         'company' => $company,
                         'employee' => $author,
@@ -35,5 +35,17 @@ class EmployeeLogViewHelper
         }
 
         return $logsCollection;
+    }
+
+    /**
+     * Information about the employee.
+     */
+    public static function employee(Employee $employee): array
+    {
+        return [
+            'id' => $employee->id,
+            'name' => $employee->name,
+            'avatar' => ImageHelper::getAvatar($employee, 80),
+        ];
     }
 }

--- a/app/Http/ViewHelpers/Employee/EmployeeOneOnOneViewHelper.php
+++ b/app/Http/ViewHelpers/Employee/EmployeeOneOnOneViewHelper.php
@@ -64,7 +64,7 @@ class EmployeeOneOnOneViewHelper
                 'manager' => [
                     'id' => $oneOnOne->manager->id,
                     'name' => $oneOnOne->manager->name,
-                    'avatar' => ImageHelper::getAvatar($oneOnOne->manager),
+                    'avatar' => ImageHelper::getAvatar($oneOnOne->manager, 22),
                     'url' => route('employees.show', [
                         'company' => $company,
                         'employee' => $oneOnOne->manager,
@@ -140,7 +140,7 @@ class EmployeeOneOnOneViewHelper
             'employee' => [
                 'id' => $entry->employee->id,
                 'name' => $entry->employee->name,
-                'avatar' => ImageHelper::getAvatar($entry->employee),
+                'avatar' => ImageHelper::getAvatar($entry->employee, 22),
                 'url' => route('employees.show', [
                     'company' => $company,
                     'employee' => $entry->employee,
@@ -149,7 +149,7 @@ class EmployeeOneOnOneViewHelper
             'manager' => [
                 'id' => $entry->manager->id,
                 'name' => $entry->manager->name,
-                'avatar' => ImageHelper::getAvatar($entry->manager),
+                'avatar' => ImageHelper::getAvatar($entry->manager, 22),
                 'url' => route('employees.show', [
                     'company' => $company,
                     'employee' => $entry->manager,

--- a/app/Http/ViewHelpers/Employee/EmployeeSurveysViewHelper.php
+++ b/app/Http/ViewHelpers/Employee/EmployeeSurveysViewHelper.php
@@ -134,7 +134,7 @@ class EmployeeSurveysViewHelper
             $directReportsCollection->push([
                 'id' => $answer->employee->id,
                 'name' => $answer->employee->name,
-                'avatar' => ImageHelper::getAvatar($answer->employee),
+                'avatar' => ImageHelper::getAvatar($answer->employee, 22),
                 'url' => route('employees.show', [
                     'company' => $answer->employee->company_id,
                     'employee' => $answer->employee->id,
@@ -155,7 +155,7 @@ class EmployeeSurveysViewHelper
                 'employee' => $answer->reveal_identity_to_manager ? [
                     'id' => $answer->employee->id,
                     'name' => $answer->employee->name,
-                    'avatar' => ImageHelper::getAvatar($answer->employee),
+                    'avatar' => ImageHelper::getAvatar($answer->employee, 22),
                     'url' => route('employees.show', [
                         'company' => $answer->employee->company_id,
                         'employee' => $answer->employee->id,

--- a/resources/js/Pages/Adminland/Employee/Partials/EmployeeList.vue
+++ b/resources/js/Pages/Adminland/Employee/Partials/EmployeeList.vue
@@ -14,9 +14,8 @@
         v-for="currentEmployee in employees" :key="currentEmployee.id"
         class="flex items-center lh-copy pa3-l pa1 ph0-l bb b--black-10 employee-item"
       >
-        <img loading="lazy" class="w2 h2 w3-ns h3-ns br-100" :src="currentEmployee.avatar" width="64" height="64"
-             alt="avatar"
-        />
+        <avatar :avatar="currentEmployee.avatar" :size="64" :classes="'w2 h2 w3-ns h3-ns br-100'" />
+
         <div class="pl3 flex-auto">
           <span class="db black-70 f4 mb1" :name="currentEmployee.name" :data-cy="currentEmployee.id" :data-invitation-link="currentEmployee.invitation_link">
             {{ currentEmployee.name }} <span v-if="currentEmployee.lock_status" data-cy="lock-status">🔐</span>
@@ -51,7 +50,13 @@
 </template>
 
 <script>
+import Avatar from '@/Shared/Avatar';
+
 export default {
+  components: {
+    Avatar,
+  },
+
   props: {
     employees: {
       type: Array,

--- a/resources/js/Pages/Adminland/Expense/Partials/Employees.vue
+++ b/resources/js/Pages/Adminland/Expense/Partials/Employees.vue
@@ -73,7 +73,7 @@
     <div v-show="localEmployees.length > 0" class="ba bb-gray mt2 br2 employees-list">
       <div v-for="employee in localEmployees" :key="employee.id" class="pa2 db bb-gray bb bb-gray-hover" data-cy="employees-list">
         <span class="pl3 db relative team-member">
-          <img loading="lazy" :src="employee.avatar" class="br-100 absolute avatar" alt="avatar" />
+          <avatar :avatar="employee.avatar" :size="23" :classes="'br-100 absolute avatar'" />
 
           <inertia-link :href="employee.url">{{ employee.name }}</inertia-link>
 
@@ -96,11 +96,13 @@
 
 <script>
 import Help from '@/Shared/Help';
+import Avatar from '@/Shared/Avatar';
 import TextInput from '@/Shared/TextInput';
 import BallPulseLoader from 'vue-loaders/dist/loaders/ball-pulse';
 
 export default {
   components: {
+    Avatar,
     Help,
     TextInput,
     'ball-pulse-loader': BallPulseLoader.component

--- a/resources/js/Pages/Company/Partials/Birthdays.vue
+++ b/resources/js/Pages/Company/Partials/Birthdays.vue
@@ -29,7 +29,7 @@
     <div class="br3 bg-white box z-1 pa3 relative">
       <ul v-if="birthdays.length != 0" class="list pl0 ma0">
         <li v-for="birthday in birthdays" :key="birthday.id" class="mb3 pl3 db relative person">
-          <img loading="lazy" :src="birthday.avatar" class="br-100 absolute avatar" alt="avatar" />
+          <avatar :avatar="birthday.avatar" :size="35" :classes="'br-100 absolute avatar'" />
 
           <!-- normal mode -->
           <inertia-link :href="birthday.url" class="mb2">
@@ -52,7 +52,13 @@
 </template>
 
 <script>
+import Avatar from '@/Shared/Avatar';
+
 export default {
+  components: {
+    Avatar,
+  },
+
   props: {
     birthdays: {
       type: Array,

--- a/resources/js/Pages/Company/Partials/Employees.vue
+++ b/resources/js/Pages/Company/Partials/Employees.vue
@@ -28,8 +28,8 @@
         <p>{{ $t('company.employees_total', { count: statistics.number_of_employees }) }}</p>
 
         <div class="flex items-center relative tr employees">
-          <img v-for="employee in employees.ten_random_employees" :key="employee.id" :src="employee.avatar" alt="avatar" class="br-100 small-avatar pointer"
-               width="32" height="32" @click="navigateTo(employee)"
+          <avatar v-for="employee in employees.ten_random_employees" :key="employee.id" :avatar="employee.avatar" :size="32" :url="employee.url"
+                  :classes="'br-100 small-avatar pointer'"
           />
           <div v-if="employees.number_of_employees_left > 0" class="pl2 f7 more-members relative gray">
             {{ $t('project.menu_other_member', { count: employees.number_of_employees_left }) }}
@@ -50,7 +50,13 @@
 </template>
 
 <script>
+import Avatar from '@/Shared/Avatar';
+
 export default {
+  components: {
+    Avatar,
+  },
+
   props: {
     statistics: {
       type: Object,
@@ -59,12 +65,6 @@ export default {
     employees: {
       type: Object,
       default: null,
-    },
-  },
-
-  methods: {
-    navigateTo(employee) {
-      this.$inertia.visit(employee.url);
     },
   },
 };

--- a/resources/js/Pages/Company/Partials/GuessEmployeeGame.vue
+++ b/resources/js/Pages/Company/Partials/GuessEmployeeGame.vue
@@ -83,15 +83,19 @@
           <span>{{ $t('company.guess_employee_game_play_again') }}</span>
         </p>
       </div>
-      <img loading="lazy" class="absolute bottom-0 right-1 avatar" alt="avatar to find" :src="updatedGame.avatar_to_find" width="64"
-           height="64"
-      />
+      <avatar :avatar="updatedGame.avatar_to_find" :size="64" :classes="'absolute bottom-0 right-1 avatar'" />
     </div>
   </div>
 </template>
 
 <script>
+import Avatar from '@/Shared/Avatar';
+
 export default {
+  components: {
+    Avatar,
+  },
+
   props: {
     game: {
       type: Object,

--- a/resources/js/Pages/Company/Partials/NewHires.vue
+++ b/resources/js/Pages/Company/Partials/NewHires.vue
@@ -29,7 +29,7 @@
     <div class="br3 bg-white box z-1 pa3 relative">
       <ul v-if="hires.length != 0" class="list pl0 ma0">
         <li v-for="hire in hires" :key="hire.id" class="mb3 pl3 db relative person">
-          <img loading="lazy" :src="hire.avatar" class="br-100 absolute avatar" alt="avatar" />
+          <avatar :avatar="hire.avatar" :size="35" :classes="'br-100 absolute avatar'" />
 
           <!-- normal mode -->
           <inertia-link :href="hire.url" class="mb2">
@@ -55,7 +55,13 @@
 </template>
 
 <script>
+import Avatar from '@/Shared/Avatar';
+
 export default {
+  components: {
+    Avatar,
+  },
+
   props: {
     hires: {
       type: Array,

--- a/resources/js/Pages/Company/Partials/Teams.vue
+++ b/resources/js/Pages/Company/Partials/Teams.vue
@@ -30,8 +30,8 @@
           <inertia-link :href="team.url" class="ma0">{{ team.name }}</inertia-link>
           <div class="flex items-center">
             <div class="di">
-              <img v-for="employee in team.employees" :key="employee.id" :src="employee.avatar" alt="avatar" class="br-100 small-avatar pointer"
-                   width="32" height="32" @click="navigateTo(employee)"
+              <avatar v-for="employee in team.employees" :key="employee.id" :url="employee.url" :avatar="employee.avatar" :size="32"
+                      :classes="'br-100 small-avatar pointer'"
               />
             </div>
 
@@ -50,7 +50,13 @@
 </template>
 
 <script>
+import Avatar from '@/Shared/Avatar';
+
 export default {
+  components: {
+    Avatar,
+  },
+
   props: {
     statistics: {
       type: Object,
@@ -59,12 +65,6 @@ export default {
     teams: {
       type: Object,
       default: null,
-    },
-  },
-
-  methods: {
-    navigateTo(employee) {
-      this.$inertia.visit(employee.url);
     },
   },
 };

--- a/resources/js/Pages/Company/Project/Decisions/Index.vue
+++ b/resources/js/Pages/Company/Project/Decisions/Index.vue
@@ -137,7 +137,7 @@
             <div v-show="form.employees.length > 0" class="ba bb-gray mb3 mt4">
               <div v-for="employee in form.employees" :key="employee.id" class="pa2 db bb-gray bb" data-cy="members-list">
                 <span class="pl3 db relative deciders">
-                  <img loading="lazy" :src="employee.avatar" class="br-100 absolute avatar" alt="avatar" />
+                  <avatar :avatar="employee.avatar" :size="22" :classes="'br-100 absolute avatar'" />
 
                   {{ employee.name }}
 
@@ -248,10 +248,12 @@ import 'vue-loaders/dist/vue-loaders.css';
 import BallPulseLoader from 'vue-loaders/dist/loaders/ball-pulse';
 import LoadingButton from '@/Shared/LoadingButton';
 import Help from '@/Shared/Help';
+import Avatar from '@/Shared/Avatar';
 
 export default {
   components: {
     Layout,
+    Avatar,
     ProjectMenu,
     SmallNameAndAvatar,
     IconDelete,

--- a/resources/js/Pages/Company/Project/Members/Index.vue
+++ b/resources/js/Pages/Company/Project/Members/Index.vue
@@ -172,7 +172,7 @@
                 <li v-for="member in localMembers" :key="member.id" :data-cy="'member-' + member.id" class="pa3 bb bb-gray flex items-center">
                   <!-- avatar -->
                   <div class="mr3">
-                    <img :src="member.avatar" alt="avatar" height="64" width="64" class="br-100" />
+                    <avatar :avatar="member.avatar" :size="64" :classes="'br-100'" />
                   </div>
 
                   <!-- name + information -->
@@ -242,10 +242,12 @@ import ProjectMenu from '@/Pages/Company/Project/Partials/ProjectMenu';
 import TextInput from '@/Shared/TextInput';
 import SelectBox from '@/Shared/Select';
 import LoadingButton from '@/Shared/LoadingButton';
+import Avatar from '@/Shared/Avatar';
 
 export default {
   components: {
     Layout,
+    Avatar,
     ProjectMenu,
     TextInput,
     SelectBox,

--- a/resources/js/Pages/Company/Project/Messages/Show.vue
+++ b/resources/js/Pages/Company/Project/Messages/Show.vue
@@ -76,7 +76,7 @@
 
           <div v-if="message.author" class="flex mb4">
             <div class="mr3">
-              <img :src="message.author.avatar" alt="avatar" height="64" width="64" class="br-100" />
+              <avatar :avatar="message.author.avatar" :size="64" :classes="'br-100'" />
             </div>
 
             <div>
@@ -142,11 +142,13 @@
 <script>
 import Layout from '@/Shared/Layout';
 import ProjectMenu from '@/Pages/Company/Project/Partials/ProjectMenu';
+import Avatar from '@/Shared/Avatar';
 
 export default {
   components: {
     Layout,
     ProjectMenu,
+    Avatar,
   },
 
   props: {

--- a/resources/js/Pages/Company/Project/Partials/ProjectLead.vue
+++ b/resources/js/Pages/Company/Project/Partials/ProjectLead.vue
@@ -32,7 +32,7 @@
     <template v-if="localProject.project_lead">
       <div class="lh-copy ma0">
         <span class="db project-lead relative">
-          <img loading="lazy" :src="localProject.project_lead.avatar" class="br-100 absolute avatar" alt="avatar" />
+          <avatar :avatar="localProject.project_lead.avatar" :size="35" :classes="'br-100 absolute avatar'" />
           <inertia-link :href="'/' + $page.props.auth.company.id + '/employees/' + localProject.project_lead.id" class="mb2" data-cy="current-project-lead">
             {{ localProject.project_lead.name }}
           </inertia-link>
@@ -132,10 +132,12 @@ import IconDelete from '@/Shared/IconDelete';
 import 'vue-loaders/dist/vue-loaders.css';
 import BallPulseLoader from 'vue-loaders/dist/loaders/ball-pulse';
 import vClickOutside from 'v-click-outside';
+import Avatar from '@/Shared/Avatar';
 
 export default {
   components: {
     Errors,
+    Avatar,
     IconDelete,
     'ball-pulse-loader': BallPulseLoader.component,
   },

--- a/resources/js/Pages/Company/Project/Partials/ProjectMenu.vue
+++ b/resources/js/Pages/Company/Project/Partials/ProjectMenu.vue
@@ -35,9 +35,7 @@
       <div v-if="project.members.length > 0">
         <p class="mt0 mb2 f7 gray">Project members</p>
         <div class="flex items-center relative tr">
-          <img v-for="member in project.members" :key="member.id" :src="member.avatar" alt="avatar" class="br-100 small-avatar"
-               width="32" height="32"
-          />
+          <avatar v-for="member in project.members" :key="member.id" :avatar="member.avatar" :size="32" :classes="'br-100 small-avatar'" />
           <div v-if="project.other_members_counter > 0" class="pl2 f7 more-members relative gray">
             {{ $t('project.menu_other_member', { count: project.other_members_counter }) }}
           </div>
@@ -77,7 +75,13 @@
 </template>
 
 <script>
+import Avatar from '@/Shared/Avatar';
+
 export default {
+  components: {
+    Avatar,
+  },
+
   props: {
     project: {
       type: Object,

--- a/resources/js/Pages/Company/Project/Tasks/Show.vue
+++ b/resources/js/Pages/Company/Project/Tasks/Show.vue
@@ -233,7 +233,7 @@ input[type=checkbox] {
           <!-- information about the author -->
           <div v-if="localTask.author" class="flex mb4">
             <div class="mr2">
-              <img :src="localTask.author.avatar" alt="avatar" height="35" width="35" class="br-100" />
+              <avatar :avatar="localTask.author.avatar" :size="35" :classes="'br-100'" />
             </div>
 
             <div>
@@ -327,10 +327,12 @@ import TextArea from '@/Shared/TextArea';
 import SelectBox from '@/Shared/Select';
 import LoadingButton from '@/Shared/LoadingButton';
 import TextDuration from '@/Shared/TextDuration';
+import Avatar from '@/Shared/Avatar';
 
 export default {
   components: {
     Layout,
+    Avatar,
     ProjectMenu,
     'ball-clip-rotate': BallClipRotate.component,
     TextInput,

--- a/resources/js/Pages/Company/Skill/Show.vue
+++ b/resources/js/Pages/Company/Skill/Show.vue
@@ -115,7 +115,7 @@
         <!-- list of employees with this skill -->
         <ul class="list pl0 mb0" data-cy="list-of-employees">
           <li v-for="employee in employees" :key="employee.id" :data-cy="'employee-' + employee.id" class="relative ba bb-gray bb-gray-hover pa3 br3 flex items-center employee">
-            <img loading="lazy" :src="employee.avatar" class="br-100 avatar" alt="avatar" />
+            <avatar :avatar="employee.avatar" :size="64" :classes="'avatar br-100'" />
 
             <div class="ml3 mw-100">
               <inertia-link :href="employee.url">{{ employee.name }}</inertia-link>
@@ -154,10 +154,12 @@ import Help from '@/Shared/Help';
 import TextInput from '@/Shared/TextInput';
 import LoadingButton from '@/Shared/LoadingButton';
 import Errors from '@/Shared/Errors';
+import Avatar from '@/Shared/Avatar';
 
 export default {
   components: {
     Layout,
+    Avatar,
     Help,
     TextInput,
     Errors,

--- a/resources/js/Pages/Dashboard/HR/Partials/Timesheets.vue
+++ b/resources/js/Pages/Dashboard/HR/Partials/Timesheets.vue
@@ -56,15 +56,13 @@
           <!-- avatars -->
           <div v-if="data.number_of_timesheets > 0" class="pl6-ns pl3 mb3">
             <div class="flex items-center relative tr all-avatars">
-              <img v-for="member in data.employees" :key="member.id" :src="member.avatar" alt="avatar" class="br-100 small-avatar"
-                   width="32" height="32"
-              />
+              <avatar v-for="member in data.employees" :key="member.id" :avatar="member.avatar" :size="32" :classes="'br-100 small-avatar'" />
             </div>
           </div>
         </div>
 
         <!-- CTA -->
-        <inertia-link :href="data.url_view_all" class="btn w-auto-ns w-100 mr2 pv2 ph3 mr3">{{ $t('app.view') }}</inertia-link>
+        <inertia-link v-if="data.number_of_timesheets > 0" :href="data.url_view_all" class="btn w-auto-ns w-100 mr2 pv2 ph3 mr3">{{ $t('app.view') }}</inertia-link>
       </div>
     </div>
   </div>
@@ -72,10 +70,12 @@
 
 <script>
 import Help from '@/Shared/Help';
+import Avatar from '@/Shared/Avatar';
 
 export default {
   components: {
     Help,
+    Avatar,
   },
 
   props: {

--- a/resources/js/Pages/Dashboard/HR/Timesheets/Index.vue
+++ b/resources/js/Pages/Dashboard/HR/Timesheets/Index.vue
@@ -78,7 +78,7 @@
               <!-- identity -->
               <div class="mb3">
                 <span class="pl3 db relative team-member">
-                  <img loading="lazy" :src="directReport.avatar" alt="avatar" class="br-100 absolute avatar" />
+                  <avatar :avatar="directReport.avatar" :size="64" :classes="'br-100 absolute avatar'" />
                   <inertia-link :href="directReport.url" class="mb2">{{ directReport.name }}</inertia-link>
                   <span class="title db f7 mt1">
                     {{ directReport.position }}
@@ -115,12 +115,14 @@
 import Layout from '@/Shared/Layout';
 import Help from '@/Shared/Help';
 import LoadingButton from '@/Shared/LoadingButton';
+import Avatar from '@/Shared/Avatar';
 
 export default {
   components: {
     Layout,
     Help,
     LoadingButton,
+    Avatar,
   },
 
   props: {

--- a/resources/js/Pages/Dashboard/Manager/Partials/ContractRenewal.vue
+++ b/resources/js/Pages/Dashboard/Manager/Partials/ContractRenewal.vue
@@ -48,7 +48,7 @@
           <!-- identity -->
           <div>
             <span class="pl3 db relative team-member">
-              <img loading="lazy" :src="directReport.avatar" alt="avatar" class="br-100 absolute avatar" />
+              <avatar :avatar="directReport.avatar" :size="35" :classes="'br-100 absolute avatar'" />
               <inertia-link :href="directReport.url" class="mb2">{{ directReport.name }}</inertia-link>
               <span class="title db f7 mt1">
                 {{ directReport.position }}
@@ -72,10 +72,12 @@
 
 <script>
 import Help from '@/Shared/Help';
+import Avatar from '@/Shared/Avatar';
 
 export default {
   components: {
     Help,
+    Avatar,
   },
 
   props: {

--- a/resources/js/Pages/Dashboard/Manager/Partials/OneOnOneWithDirectReport.vue
+++ b/resources/js/Pages/Dashboard/Manager/Partials/OneOnOneWithDirectReport.vue
@@ -48,7 +48,7 @@
           <!-- identity -->
           <div>
             <span class="pl3 db relative team-member">
-              <img loading="lazy" :src="directReport.avatar" alt="avatar" class="br-100 absolute avatar" />
+              <avatar :avatar="directReport.avatar" :size="35" :classes="'br-100 absolute avatar'" />
               <inertia-link :href="directReport.url" class="mb2">{{ directReport.name }}</inertia-link>
               <span class="title db f7 mt1">
                 {{ directReport.position }}
@@ -68,10 +68,12 @@
 
 <script>
 import Help from '@/Shared/Help';
+import Avatar from '@/Shared/Avatar';
 
 export default {
   components: {
     Help,
+    Avatar,
   },
 
   props: {

--- a/resources/js/Pages/Dashboard/Manager/Partials/TimesheetApprovals.vue
+++ b/resources/js/Pages/Dashboard/Manager/Partials/TimesheetApprovals.vue
@@ -46,9 +46,7 @@
           <!-- avatars -->
           <div v-if="timesheetsStats.employees.length > 0" class="pl6-ns pl3 mb3">
             <div class="flex items-center relative tr all-avatars">
-              <img v-for="member in timesheetsStats.employees" :key="member.id" :src="member.avatar" alt="avatar" class="br-100 small-avatar"
-                   width="32" height="32"
-              />
+              <avatar v-for="member in timesheetsStats.employees" :key="member.id" :avatar="member.avatar" :size="32" :classes="'br-100 small-avatar'" />
             </div>
           </div>
         </div>
@@ -62,10 +60,12 @@
 
 <script>
 import Help from '@/Shared/Help';
+import Avatar from '@/Shared/Avatar';
 
 export default {
   components: {
     Help,
+    Avatar,
   },
 
   props: {

--- a/resources/js/Pages/Dashboard/Manager/Timesheets/Index.vue
+++ b/resources/js/Pages/Dashboard/Manager/Timesheets/Index.vue
@@ -79,7 +79,7 @@
               <!-- identity -->
               <div class="mb3">
                 <span class="pl3 db relative team-member">
-                  <img loading="lazy" :src="directReport.avatar" alt="avatar" class="br-100 absolute avatar" />
+                  <avatar :avatar="directReport.avatar" :size="35" :classes="'br-100 absolute avatar'" />
                   <inertia-link :href="directReport.url" class="mb2">{{ directReport.name }}</inertia-link>
                   <span class="title db f7 mt1">
                     {{ directReport.position }}
@@ -114,12 +114,14 @@
 
 <script>
 import Layout from '@/Shared/Layout';
+import Avatar from '@/Shared/Avatar';
 import Help from '@/Shared/Help';
 import LoadingButton from '@/Shared/LoadingButton';
 
 export default {
   components: {
     Layout,
+    Avatar,
     Help,
     LoadingButton,
   },

--- a/resources/js/Pages/Dashboard/Me/Partials/ECoffee.vue
+++ b/resources/js/Pages/Dashboard/Me/Partials/ECoffee.vue
@@ -46,7 +46,7 @@
       <!-- avatars -->
       <div class="absolute-ns avatars tc">
         <img class="avatar br-100" loading="lazy" src="/img/streamline-icon-coffee-idea-sparking@140x140.png" alt="avatar" />
-        <img class="avatar br-100" loading="lazy" :src="localeCoffee.other_employee.avatar" alt="avatar" />
+        <avatar :avatar="localeCoffee.other_employee.avatar" :size="55" :classes="'avatar br-100'" />
       </div>
     </div>
 
@@ -66,10 +66,12 @@
 
 <script>
 import Help from '@/Shared/Help';
+import Avatar from '@/Shared/Avatar';
 import LoadingButton from '@/Shared/LoadingButton';
 
 export default {
   components: {
+    Avatar,
     Help,
     LoadingButton,
   },

--- a/resources/js/Pages/Dashboard/Me/Partials/OneOnOneWithManager.vue
+++ b/resources/js/Pages/Dashboard/Me/Partials/OneOnOneWithManager.vue
@@ -48,7 +48,7 @@
           <!-- identity -->
           <div>
             <span class="pl3 db relative team-member">
-              <img loading="lazy" :src="manager.avatar" alt="avatar" class="br-100 absolute avatar" />
+              <avatar :avatar="manager.avatar" :size="35" :classes="'br-100 absolute avatar'" />
               <inertia-link :href="manager.url" class="mb2">{{ manager.name }}</inertia-link>
               <span class="title db f7 mt1">
                 {{ manager.position }}
@@ -68,10 +68,12 @@
 
 <script>
 import Help from '@/Shared/Help';
+import Avatar from '@/Shared/Avatar';
 
 export default {
   components: {
     Help,
+    Avatar,
   },
 
   props: {

--- a/resources/js/Pages/Dashboard/Team/Partials/Birthdays.vue
+++ b/resources/js/Pages/Dashboard/Team/Partials/Birthdays.vue
@@ -31,7 +31,7 @@
       <!-- all birthdays -->
       <div v-for="employee in birthdays" :key="employee.id" class="pa3 fl w-third-l w-100" data-cy="birthdays-list">
         <span class="pl3 db relative team-member">
-          <img loading="lazy" :src="employee.avatar" class="br-100 absolute avatar" alt="avatar" />
+          <avatar :avatar="employee.avatar" :size="35" :classes="'br-100 absolute avatar'" />
 
           <!-- normal mode -->
           <inertia-link :href="employee.url" class="mb2">
@@ -49,8 +49,13 @@
 </template>
 
 <script>
+import Avatar from '@/Shared/Avatar';
 
 export default {
+  components: {
+    Avatar,
+  },
+
   props: {
     birthdays: {
       type: Array,

--- a/resources/js/Pages/Dashboard/Team/Partials/RecentShips.vue
+++ b/resources/js/Pages/Dashboard/Team/Partials/RecentShips.vue
@@ -26,7 +26,7 @@
           <inertia-link :href="ship.url" class="ma0 pa0" :data-cy="'ship-list-item-' + ship.id">{{ ship.title }}</inertia-link>
           <ul class="list ma0">
             <li v-for="employee in ship.employees" :key="employee.id" class="mr1 di">
-              <inertia-link :href="employee.url" class="ship-avatar"><img loading="lazy" :src="employee.avatar" class="br-100 relative mr1 dib-ns dn" alt="avatar" :data-cy="'ship-list-' + ship.id + '-avatar-' + employee.id" /></inertia-link>
+              <avatar :avatar="employee.avatar" :url="employee.url" :size="17" :classes="'br-100 relative mr1 dib-ns dn'" />
             </li>
           </ul>
         </div>
@@ -41,7 +41,13 @@
 </template>
 
 <script>
+import Avatar from '@/Shared/Avatar';
+
 export default {
+  components: {
+    Avatar,
+  },
+
   props: {
     recentShips: {
       type: Array,

--- a/resources/js/Pages/Dashboard/Team/Partials/UpcomingHiringDateAnniversaries.vue
+++ b/resources/js/Pages/Dashboard/Team/Partials/UpcomingHiringDateAnniversaries.vue
@@ -25,7 +25,7 @@
     <div class="cf mw7 center br3 mb3 bg-white box">
       <div v-for="employee in hiringDateAnniversaries" :key="employee.id" class="pa3 w-100" data-cy="new-hires-list">
         <span class="pl3 db relative team-member">
-          <img loading="lazy" :src="employee.avatar" class="br-100 absolute avatar" alt="avatar" />
+          <avatar :avatar="employee.avatar" :size="35" :classes="'br-100 absolute avatar'" />
 
           <!-- normal mode -->
           <inertia-link :href="employee.url" class="mb2">
@@ -43,9 +43,11 @@
 
 <script>
 import Help from '@/Shared/Help';
+import Avatar from '@/Shared/Avatar';
 
 export default {
   components: {
+    Avatar,
     Help,
   },
 

--- a/resources/js/Pages/Dashboard/Team/Partials/UpcomingNewHires.vue
+++ b/resources/js/Pages/Dashboard/Team/Partials/UpcomingNewHires.vue
@@ -25,7 +25,7 @@
     <div class="cf mw7 center br3 mb3 bg-white box">
       <div v-for="employee in newHires" :key="employee.id" class="pa3 w-100" data-cy="new-hires-list">
         <span class="pl3 db relative team-member">
-          <img loading="lazy" :src="employee.avatar" class="br-100 absolute avatar" alt="avatar" />
+          <avatar :avatar="employee.avatar" :size="35" :classes="'br-100 absolute avatar'" />
 
           <!-- normal mode -->
           <inertia-link :href="employee.url" class="mb2">
@@ -46,10 +46,12 @@
 </template>
 
 <script>
+import Avatar from '@/Shared/Avatar';
 import Help from '@/Shared/Help';
 
 export default {
   components: {
+    Avatar,
     Help,
   },
 

--- a/resources/js/Pages/Dashboard/Team/Partials/WorkFromHome.vue
+++ b/resources/js/Pages/Dashboard/Team/Partials/WorkFromHome.vue
@@ -31,7 +31,7 @@
       <!-- all people working from homes -->
       <div v-for="employee in workFromHomes" :key="employee.id" class="pa3 fl w-third-l w-100" data-cy="work-from-home-list">
         <span class="pl3 db relative team-member">
-          <img loading="lazy" :src="employee.avatar" class="br-100 absolute avatar" alt="avatar" />
+          <avatar :avatar="employee.avatar" :url="employee.url" :size="35" :classes="'br-100 absolute avatar'" />
 
           <!-- normal mode -->
           <inertia-link :href="employee.url" class="mb2">
@@ -52,8 +52,13 @@
 </template>
 
 <script>
+import Avatar from '@/Shared/Avatar';
 
 export default {
+  components: {
+    Avatar,
+  },
+
   props: {
     workFromHomes: {
       type: Array,

--- a/resources/js/Pages/Employee/ECoffee/Index.vue
+++ b/resources/js/Pages/Employee/ECoffee/Index.vue
@@ -43,7 +43,8 @@
         <ul v-if="eCoffees.length > 0" class="list pl0 ma0">
           <li v-for="ecoffee in eCoffees" :key="ecoffee.id" class="pa3 bb bb-gray bb-gray-hover flex items-center justify-between ecoffee-item" :data-cy="'ecoffee-title-' + ecoffee.id">
             <div class="mb1 relative">
-              <img loading="lazy" :src="ecoffee.with_employee.avatar" class="br-100 absolute avatar" alt="avatar" />
+              <avatar :avatar="ecoffee.with_employee.avatar" :size="35" :classes="'br-100 absolute avatar'" />
+
               <span class="employee-name db">
                 <inertia-link :href="ecoffee.with_employee.url" class="mb2">{{ ecoffee.with_employee.name }}</inertia-link>
               </span>
@@ -62,11 +63,13 @@
 
 <script>
 import Layout from '@/Shared/Layout';
+import Avatar from '@/Shared/Avatar';
 import Help from '@/Shared/Help';
 
 export default {
   components: {
     Help,
+    Avatar,
     Layout,
   },
 

--- a/resources/js/Pages/Employee/Index.vue
+++ b/resources/js/Pages/Employee/Index.vue
@@ -34,9 +34,8 @@
               v-for="employee in employees" :key="employee.id"
               class="flex lh-copy pa3-l pa1 ph0-l pv0-ns pv2 bb b--black-10 employee-item"
             >
-              <img loading="lazy" class="w2 h2 w3-ns h3-ns br-100" :src="employee.avatar" width="64" height="64"
-                   alt="avatar"
-              />
+              <avatar :avatar="employee.avatar" :size="64" :classes="'w2 h2 w3-ns h3-ns br-100'" />
+
               <div class="pl3">
                 <!-- name -->
                 <inertia-link class="dib pointer mb1" :href="'/' + $page.props.auth.company.id + '/employees/' + employee.id">
@@ -80,10 +79,12 @@
 
 <script>
 import Layout from '@/Shared/Layout';
+import Avatar from '@/Shared/Avatar';
 
 export default {
   components: {
     Layout,
+    Avatar,
   },
 
   props: {

--- a/resources/js/Pages/Employee/Logs/Index.vue
+++ b/resources/js/Pages/Employee/Logs/Index.vue
@@ -44,7 +44,7 @@
       <div class="mw7 center br3 mb5 bg-white box relative z-1">
         <div class="relative pt5">
           <!-- AVATAR -->
-          <img loading="lazy" :src="employee.avatar" class="avatar absolute br-100 db center" alt="avatar" />
+          <avatar :avatar="employee.avatar" :size="80" :classes="'avatar absolute br-100 db center'" />
 
           <h2 class="pa3 tc normal mb4">
             {{ $t('employee.audit_log_title') }}
@@ -53,7 +53,7 @@
           <ul class="list pl0 mt0 mb0 center" data-cy="logs-list">
             <li v-for="log in logs" :key="log.id" class="flex items-center lh-copy pa3 bb b--black-10 log-item">
               <!-- avatar -->
-              <img loading="lazy" :src="log.author.avatar" class="author-avatar br-100" alt="avatar" />
+              <avatar :avatar="log.author.avatar" :size="34" :classes="'author-avatar br-100'" />
 
               <div>
                 <div class="db f7 mb2">
@@ -93,10 +93,12 @@
 
 <script>
 import Layout from '@/Shared/Layout';
+import Avatar from '@/Shared/Avatar';
 
 export default {
   components: {
     Layout,
+    Avatar,
   },
 
   props: {

--- a/resources/js/Pages/Employee/Partials/Avatar.vue
+++ b/resources/js/Pages/Employee/Partials/Avatar.vue
@@ -19,18 +19,19 @@
                 @success="onSuccess"
                 @error="onError"
     >
-      <img :class="{'black-white':(employee.locked)}" loading="lazy" :src="localAvatar" alt="avatar" />
-      <!-- <button>{{ $t('account.import_employees_import_cta') }}</button> -->
+      <avatar :avatar="localAvatar" :size="300" />
     </uploadcare>
   </div>
 </template>
 
 <script>
 import Uploadcare from 'uploadcare-vue';
+import Avatar from '@/Shared/Avatar';
 
 export default {
   components: {
     Uploadcare,
+    Avatar,
   },
 
   props: {

--- a/resources/js/Pages/Employee/Partials/ECoffee.vue
+++ b/resources/js/Pages/Employee/Partials/ECoffee.vue
@@ -39,7 +39,7 @@
       <ul v-if="ecoffees.eCoffees.length > 0" data-cy="e-coffee-list" class="list pl0 ma0">
         <li v-for="ecoffee in ecoffees.eCoffees" :key="ecoffee.id" class="pa3 bb bb-gray bb-gray-hover flex items-center justify-between ecoffee-item" :data-cy="'ecoffee-title-' + ecoffee.id">
           <div class="mb1 relative">
-            <img loading="lazy" :src="ecoffee.with_employee.avatar" class="br-100 absolute avatar" alt="avatar" />
+            <avatar :avatar="ecoffee.with_employee.avatar" :size="35" :classes="'br-100 absolute avatar'" />
             <span class="employee-name db">
               <inertia-link :href="ecoffee.with_employee.url" class="mb2">{{ ecoffee.with_employee.name }}</inertia-link>
             </span>
@@ -60,10 +60,12 @@
 
 <script>
 import Help from '@/Shared/Help';
+import Avatar from '@/Shared/Avatar';
 
 export default {
   components: {
     Help,
+    Avatar,
   },
 
   props: {

--- a/resources/js/Pages/Employee/Partials/Hierarchy.vue
+++ b/resources/js/Pages/Employee/Partials/Hierarchy.vue
@@ -149,7 +149,7 @@
           </p>
           <ul class="list mv0">
             <li v-for="manager in localManagersOfEmployee" :key="manager.id" class="mb3 relative bb-gray-hover">
-              <img loading="lazy" :src="manager.avatar" class="br-100 absolute avatar" alt="avatar" />
+              <avatar :avatar="manager.avatar" :size="35" :classes="'br-100 absolute avatar'" />
               <inertia-link :href="manager.url" class="mb2">
                 {{ manager.name }}
               </inertia-link>
@@ -202,7 +202,10 @@
           </p>
           <ul class="list mv0">
             <li v-for="directReport in localDirectReports" :key="directReport.id" class="mb3 relative bb-gray-hover">
-              <img loading="lazy" :src="directReport.avatar" class="br-100 absolute avatar" alt="avatar" />
+              <!-- avatar -->
+              <avatar :avatar="directReport.avatar" :size="35" :classes="'br-100 absolute avatar'" />
+
+              <!-- name -->
               <inertia-link :href="directReport.url" class="mb2">
                 {{ directReport.name }}
               </inertia-link>
@@ -252,6 +255,7 @@
 
 <script>
 import IconDelete from '@/Shared/IconDelete';
+import Avatar from '@/Shared/Avatar';
 import vClickOutside from 'v-click-outside';
 import 'vue-loaders/dist/vue-loaders.css';
 import BallPulseLoader from 'vue-loaders/dist/loaders/ball-pulse';
@@ -260,6 +264,7 @@ export default {
   components: {
     'ball-pulse-loader': BallPulseLoader.component,
     IconDelete,
+    Avatar,
   },
 
   directives: {

--- a/resources/js/Pages/Employee/Work/Partials/RecentShips.vue
+++ b/resources/js/Pages/Employee/Work/Partials/RecentShips.vue
@@ -30,7 +30,7 @@
           <inertia-link :href="ship.url" class="ma0 pa0" :data-cy="'ship-list-item-' + ship.id">{{ ship.title }}</inertia-link>
           <ul class="list ma0">
             <li v-for="employee in ship.employees" :key="employee.id" class="mr1 di">
-              <inertia-link :href="employee.url" class="ship-avatar"><img loading="lazy" :src="employee.avatar" class="br-100 relative mr1 dib-ns dn" alt="avatar" :data-cy="'ship-list-' + ship.id + '-avatar-' + employee.id" /></inertia-link>
+              <avatar :avatar="employee.avatar" :url="employee.url" :size="22" :classes="'br-100 relative mr1 dib-ns dn'" />
             </li>
           </ul>
         </div>
@@ -46,10 +46,12 @@
 
 <script>
 import Help from '@/Shared/Help';
+import Avatar from '@/Shared/Avatar';
 
 export default {
   components: {
-    Help
+    Help,
+    Avatar,
   },
 
   props: {

--- a/resources/js/Shared/Avatar.vue
+++ b/resources/js/Shared/Avatar.vue
@@ -5,8 +5,10 @@ span {
 </style>
 
 <template>
-  <img :loading="loading" :class="classes" :src="avatar.normal" :width="size" :height="size"
+  <img :loading="loading" :class="classes" class="pointer" :src="avatar.normal" :width="size"
+       :height="size"
        :srcset="avatar.normal + ' 1x,' + avatar.retina + ' 2x'" :alt="alt"
+       @click="navigateTo()"
   />
 </template>
 
@@ -39,6 +41,12 @@ export default {
     }
   },
 
-
+  methods: {
+    navigateTo() {
+      if (this.url) {
+        this.$inertia.visit(this.url);
+      }
+    },
+  },
 };
 </script>

--- a/resources/js/Shared/Avatar.vue
+++ b/resources/js/Shared/Avatar.vue
@@ -1,0 +1,46 @@
+<style lang="scss" scoped>
+span {
+  margin-left: 29px;
+}
+</style>
+
+<template>
+  <div>
+    <img :loading="loading" :class="classes" :src="avatar.normal" :width="size" :height="size"
+         :srcset="avatar.normal + ' 1x,' + avatar.retina + ' 2x'" :alt="alt"
+    />
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    avatar: {
+      type: Object,
+      default: null,
+    },
+    classes: {
+      type: String,
+      default: null,
+    },
+    url: {
+      type: String,
+      default: null,
+    },
+    size: {
+      type: Number,
+      default: 0,
+    },
+    loading: {
+      type: String,
+      default: 'lazy',
+    },
+    alt: {
+      type: String,
+      default: 'avatar',
+    }
+  },
+
+
+};
+</script>

--- a/resources/js/Shared/Avatar.vue
+++ b/resources/js/Shared/Avatar.vue
@@ -5,11 +5,9 @@ span {
 </style>
 
 <template>
-  <div>
-    <img :loading="loading" :class="classes" :src="avatar.normal" :width="size" :height="size"
-         :srcset="avatar.normal + ' 1x,' + avatar.retina + ' 2x'" :alt="alt"
-    />
-  </div>
+  <img :loading="loading" :class="classes" :src="avatar.normal" :width="size" :height="size"
+       :srcset="avatar.normal + ' 1x,' + avatar.retina + ' 2x'" :alt="alt"
+  />
 </template>
 
 <script>

--- a/resources/js/Shared/SmallNameAndAvatar.vue
+++ b/resources/js/Shared/SmallNameAndAvatar.vue
@@ -6,7 +6,9 @@ span {
 
 <template>
   <div class="relative di">
-    <img loading="lazy" :src="avatar" class="absolute br-100" alt="avatar" :style="style" />
+    <img loading="lazy" :src="avatar.normal" :srcset="avatar.normal + ' 1x,' + avatar.retina + ' 2x'" class="absolute br-100" alt="avatar"
+         :style="style"
+    />
     <inertia-link v-if="url" :href="url" :class="classes + ' ' + fontSize" :style="avatarMarginLeft">{{ name }}</inertia-link>
     <span v-else :class="classes + ' ' + fontSize" :style="avatarMarginLeft">
       {{ name }}

--- a/resources/js/Shared/SmallNameAndAvatar.vue
+++ b/resources/js/Shared/SmallNameAndAvatar.vue
@@ -24,7 +24,7 @@ export default {
       default: null,
     },
     avatar: {
-      type: String,
+      type: Object,
       default: null,
     },
     classes: {

--- a/tests/Unit/Helpers/ImageHelperTest.php
+++ b/tests/Unit/Helpers/ImageHelperTest.php
@@ -18,7 +18,10 @@ class ImageHelperTest extends TestCase
         $michael = Employee::factory()->create();
 
         $this->assertEquals(
-            'https://ui-avatars.com/api/?name='.$michael->name,
+            [
+                'normal' => 'https://ui-avatars.com/api/?name='.$michael->name.'&size=64',
+                'retina' => 'https://ui-avatars.com/api/?name='.$michael->name.'&size=128',
+            ],
             ImageHelper::getAvatar($michael)
         );
     }
@@ -32,12 +35,18 @@ class ImageHelperTest extends TestCase
         ]);
 
         $this->assertEquals(
-            $file->cdn_url,
+            [
+                'normal' => $file->cdn_url.'-/scale_crop/64x64/smart/',
+                'retina' => $file->cdn_url.'-/scale_crop/128x128/smart/',
+            ],
             ImageHelper::getAvatar($dwight)
         );
 
         $this->assertEquals(
-            $file->cdn_url.'-/scale_crop/100x100/smart/',
+            [
+                'normal' => $file->cdn_url.'-/scale_crop/100x100/smart/',
+                'retina' => $file->cdn_url.'-/scale_crop/200x200/smart/',
+            ],
             ImageHelper::getAvatar($dwight, 100)
         );
     }

--- a/tests/Unit/ViewHelpers/Adminland/AdminExpenseViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Adminland/AdminExpenseViewHelperTest.php
@@ -66,7 +66,7 @@ class AdminExpenseViewHelperTest extends TestCase
                 0 => [
                     'id' => $dwight->id,
                     'name' => 'dwight schrute',
-                    'avatar' => ImageHelper::getAvatar($dwight),
+                    'avatar' => ImageHelper::getAvatar($dwight, 23),
                     'url' => env('APP_URL').'/'.$michael->company_id.'/employees/'.$dwight->id,
                 ],
             ],

--- a/tests/Unit/ViewHelpers/Adminland/AdminGeneralViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Adminland/AdminGeneralViewHelperTest.php
@@ -74,7 +74,7 @@ class AdminGeneralViewHelperTest extends TestCase
             [
                 'id' => $michael->id,
                 'name' => $michael->name,
-                'avatar' => ImageHelper::getAvatar($michael),
+                'avatar' => ImageHelper::getAvatar($michael, 22),
                 'url_view' => route('employees.show', [
                     'company' => $michael->company,
                     'employee' => $michael,

--- a/tests/Unit/ViewHelpers/Adminland/AdminHardwareViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Adminland/AdminHardwareViewHelperTest.php
@@ -66,7 +66,7 @@ class AdminHardwareViewHelperTest extends TestCase
                 'employee' => [
                     'id' => $michael->id,
                     'name' => $michael->name,
-                    'avatar' => ImageHelper::getAvatar($michael),
+                    'avatar' => ImageHelper::getAvatar($michael, 18),
                 ],
             ],
             $response['hardware_collection'][1]
@@ -163,7 +163,7 @@ class AdminHardwareViewHelperTest extends TestCase
                 'employee' => [
                     'id' => $michael->id,
                     'name' => $michael->name,
-                    'avatar' => ImageHelper::getAvatar($michael),
+                    'avatar' => ImageHelper::getAvatar($michael, 18),
                 ],
             ],
             $response['hardware_collection'][0]

--- a/tests/Unit/ViewHelpers/Company/CompanyNewsViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Company/CompanyNewsViewHelperTest.php
@@ -49,7 +49,7 @@ class CompanyNewsViewHelperTest extends TestCase
                     'author' => [
                         'id' => $michael->id,
                         'name' => $michael->name,
-                        'avatar' => ImageHelper::getAvatar($michael),
+                        'avatar' => ImageHelper::getAvatar($michael, 22),
                         'url' => env('APP_URL').'/'.$michael->company_id.'/employees/'.$michael->id,
                     ],
                     'written_at' => 'Jan 01, 2018',

--- a/tests/Unit/ViewHelpers/Company/CompanySkillViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Company/CompanySkillViewHelperTest.php
@@ -82,7 +82,7 @@ class CompanySkillViewHelperTest extends TestCase
             $response->toArray()[0]['name']
         );
         $this->assertEquals(
-            ImageHelper::getAvatar($michael),
+            ImageHelper::getAvatar($michael, 65),
             $response->toArray()[0]['avatar']
         );
         $this->assertEquals(
@@ -120,7 +120,7 @@ class CompanySkillViewHelperTest extends TestCase
             $response->toArray()[1]['name']
         );
         $this->assertEquals(
-            ImageHelper::getAvatar($dwight),
+            ImageHelper::getAvatar($dwight, 65),
             $response->toArray()[1]['avatar']
         );
         $this->assertEquals(

--- a/tests/Unit/ViewHelpers/Company/CompanyViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Company/CompanyViewHelperTest.php
@@ -138,7 +138,7 @@ class CompanyViewHelperTest extends TestCase
                 0 => [
                     'id' => $dwight->id,
                     'name' => 'Dwight Schrute',
-                    'avatar' => ImageHelper::getAvatar($dwight),
+                    'avatar' => ImageHelper::getAvatar($dwight, 35),
                     'birthdate' => 'January 8th',
                     'sort_key' => '2018-01-08',
                     'url' => env('APP_URL').'/'.$dwight->company_id.'/employees/'.$dwight->id,
@@ -146,7 +146,7 @@ class CompanyViewHelperTest extends TestCase
                 1 => [
                     'id' => $angela->id,
                     'name' => 'Angela Bernard',
-                    'avatar' => ImageHelper::getAvatar($angela),
+                    'avatar' => ImageHelper::getAvatar($angela, 35),
                     'birthdate' => 'January 14th',
                     'sort_key' => '2018-01-14',
                     'url' => env('APP_URL').'/'.$angela->company_id.'/employees/'.$angela->id,
@@ -195,7 +195,7 @@ class CompanyViewHelperTest extends TestCase
                 0 => [
                     'id' => $angela->id,
                     'name' => 'Angela Bernard',
-                    'avatar' => ImageHelper::getAvatar($angela),
+                    'avatar' => ImageHelper::getAvatar($angela, 35),
                     'url' => env('APP_URL').'/'.$angela->company_id.'/employees/'.$angela->id,
                     'hired_at' => 'Monday (Jan 1st)',
                     'position' => 'Assistant to the regional manager',
@@ -203,7 +203,7 @@ class CompanyViewHelperTest extends TestCase
                 1 => [
                     'id' => $dwight->id,
                     'name' => 'Dwight Schrute',
-                    'avatar' => ImageHelper::getAvatar($dwight),
+                    'avatar' => ImageHelper::getAvatar($dwight, 35),
                     'url' => env('APP_URL').'/'.$angela->company_id.'/employees/'.$dwight->id,
                     'hired_at' => 'Wednesday (Jan 3rd)',
                     'position' => 'Assistant to the regional manager',
@@ -361,7 +361,7 @@ class CompanyViewHelperTest extends TestCase
         );
 
         $this->assertEquals(
-            ImageHelper::getAvatar($game->employeeToFind),
+            ImageHelper::getAvatar($game->employeeToFind, 80),
             $array['avatar_to_find']
         );
 
@@ -405,7 +405,7 @@ class CompanyViewHelperTest extends TestCase
                 0 => [
                     'id' => $michael->id,
                     'name' => $michael->name,
-                    'avatar' => ImageHelper::getAvatar($michael),
+                    'avatar' => ImageHelper::getAvatar($michael, 32),
                     'url' => env('APP_URL').'/'.$michael->company_id.'/employees/'.$michael->id,
                 ],
             ],

--- a/tests/Unit/ViewHelpers/Company/Project/ProjectDecisionsViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Company/Project/ProjectDecisionsViewHelperTest.php
@@ -32,13 +32,13 @@ class ProjectDecisionsViewHelperTest extends TestCase
                 0 => [
                     'id' => $michael->id,
                     'name' => $michael->name,
-                    'avatar' => ImageHelper::getAvatar($michael),
+                    'avatar' => ImageHelper::getAvatar($michael, 22),
                     'url' => env('APP_URL').'/'.$michael->company_id.'/employees/'.$michael->id,
                 ],
                 1 => [
                     'id' => $jim->id,
                     'name' => $jim->name,
-                    'avatar' => ImageHelper::getAvatar($jim),
+                    'avatar' => ImageHelper::getAvatar($jim, 22),
                     'url' => env('APP_URL').'/'.$jim->company_id.'/employees/'.$jim->id,
                 ],
             ],

--- a/tests/Unit/ViewHelpers/Company/Project/ProjectMessagesViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Company/Project/ProjectMessagesViewHelperTest.php
@@ -54,7 +54,7 @@ class ProjectMessagesViewHelperTest extends TestCase
                     'author' => [
                         'id' => $michael->id,
                         'name' => $michael->name,
-                        'avatar' => ImageHelper::getAvatar($michael),
+                        'avatar' => ImageHelper::getAvatar($michael, 22),
                         'url_view' => env('APP_URL').'/'.$michael->company_id.'/employees/'.$michael->id,
                     ],
                 ],

--- a/tests/Unit/ViewHelpers/Company/Project/ProjectTasksViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Company/Project/ProjectTasksViewHelperTest.php
@@ -53,7 +53,7 @@ class ProjectTasksViewHelperTest extends TestCase
                     'assignee' => [
                         'id' => $michael->id,
                         'name' => $michael->name,
-                        'avatar' => ImageHelper::getAvatar($michael),
+                        'avatar' => ImageHelper::getAvatar($michael, 15),
                         'url' => env('APP_URL').'/'.$michael->company_id.'/employees/'.$michael->id,
                     ],
                 ],
@@ -130,7 +130,7 @@ class ProjectTasksViewHelperTest extends TestCase
                     'assignee' => [
                         'id' => $michael->id,
                         'name' => $michael->name,
-                        'avatar' => ImageHelper::getAvatar($michael),
+                        'avatar' => ImageHelper::getAvatar($michael, 15),
                         'url' => env('APP_URL').'/'.$michael->company_id.'/employees/'.$michael->id,
                     ],
                 ],
@@ -213,7 +213,7 @@ class ProjectTasksViewHelperTest extends TestCase
                 'author' => [
                     'id' => $michael->id,
                     'name' => $michael->name,
-                    'avatar' => ImageHelper::getAvatar($michael),
+                    'avatar' => ImageHelper::getAvatar($michael, 35),
                     'url' => env('APP_URL').'/'.$michael->company_id.'/employees/'.$michael->id,
                     'role' => null,
                     'added_at' => null,
@@ -222,7 +222,7 @@ class ProjectTasksViewHelperTest extends TestCase
                 'assignee' => [
                     'id' => $michael->id,
                     'name' => $michael->name,
-                    'avatar' => ImageHelper::getAvatar($michael),
+                    'avatar' => ImageHelper::getAvatar($michael, 35),
                     'url' => env('APP_URL').'/'.$michael->company_id.'/employees/'.$michael->id,
                 ],
             ],
@@ -301,7 +301,7 @@ class ProjectTasksViewHelperTest extends TestCase
                 'author' => [
                     'id' => $michael->id,
                     'name' => $michael->name,
-                    'avatar' => ImageHelper::getAvatar($michael),
+                    'avatar' => ImageHelper::getAvatar($michael, 35),
                     'role' => null,
                     'added_at' => null,
                     'position' => $michael->position->title,
@@ -310,7 +310,7 @@ class ProjectTasksViewHelperTest extends TestCase
                 'assignee' => [
                     'id' => $michael->id,
                     'name' => $michael->name,
-                    'avatar' => ImageHelper::getAvatar($michael),
+                    'avatar' => ImageHelper::getAvatar($michael, 35),
                     'url' => env('APP_URL').'/'.$michael->company_id.'/employees/'.$michael->id,
                 ],
             ],

--- a/tests/Unit/ViewHelpers/Company/Project/ProjectViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Company/Project/ProjectViewHelperTest.php
@@ -114,7 +114,7 @@ class ProjectViewHelperTest extends TestCase
             [
                 'id' => $michael->id,
                 'name' => $michael->name,
-                'avatar' => ImageHelper::getAvatar($michael),
+                'avatar' => ImageHelper::getAvatar($michael, 35),
                 'position' => [
                     'id' => $michael->position->id,
                     'title' => $michael->position->title,
@@ -143,7 +143,7 @@ class ProjectViewHelperTest extends TestCase
                 'author' => [
                     'id' => $status->author->id,
                     'name' => $status->author->name,
-                    'avatar' => ImageHelper::getAvatar($status->author),
+                    'avatar' => ImageHelper::getAvatar($status->author, 32),
                     'position' => (! $status->author->position) ? null : [
                         'id' => $status->author->position->id,
                         'title' => $status->author->position->title,

--- a/tests/Unit/ViewHelpers/Dashboard/DashboardExpenseViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Dashboard/DashboardExpenseViewHelperTest.php
@@ -51,7 +51,7 @@ class DashboardExpenseViewHelperTest extends TestCase
                     'employee' => [
                         'id' => $michael->id,
                         'name' => $michael->name,
-                        'avatar' => ImageHelper::getAvatar($michael),
+                        'avatar' => ImageHelper::getAvatar($michael, 18),
                     ],
                     'url' => env('APP_URL').'/'.$michael->company_id.'/dashboard/expenses/'.$expense->id,
                 ],
@@ -108,7 +108,7 @@ class DashboardExpenseViewHelperTest extends TestCase
                     'employee' => [
                         'id' => $michael->id,
                         'name' => $michael->name,
-                        'avatar' => ImageHelper::getAvatar($michael),
+                        'avatar' => ImageHelper::getAvatar($michael, 18),
                     ],
                     'url' => env('APP_URL').'/'.$michael->company_id.'/dashboard/expenses/'.$expenseWithoutManager->id,
                 ],
@@ -124,7 +124,7 @@ class DashboardExpenseViewHelperTest extends TestCase
                     'employee' => [
                         'id' => $michael->id,
                         'name' => $michael->name,
-                        'avatar' => ImageHelper::getAvatar($michael),
+                        'avatar' => ImageHelper::getAvatar($michael, 18),
                     ],
                     'url' => env('APP_URL').'/'.$michael->company_id.'/dashboard/expenses/'.$expenseWithManager->id,
                 ],

--- a/tests/Unit/ViewHelpers/Dashboard/DashboardManagerViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Dashboard/DashboardManagerViewHelperTest.php
@@ -72,7 +72,7 @@ class DashboardManagerViewHelperTest extends TestCase
                     'employee' => [
                         'id' => $dwight->id,
                         'name' => $dwight->name,
-                        'avatar' => ImageHelper::getAvatar($dwight),
+                        'avatar' => ImageHelper::getAvatar($dwight, 18),
                     ],
                 ],
             ],
@@ -146,7 +146,7 @@ class DashboardManagerViewHelperTest extends TestCase
                 0 => [
                     'id' => $dwight->id,
                     'name' => 'Dwight Schrute',
-                    'avatar' => ImageHelper::getAvatar($dwight),
+                    'avatar' => ImageHelper::getAvatar($dwight, 35),
                     'position' => $dwight->position->title,
                     'url' => env('APP_URL').'/'.$dwight->company_id.'/employees/'.$dwight->id,
                     'entry' => [
@@ -158,7 +158,7 @@ class DashboardManagerViewHelperTest extends TestCase
                 1 => [
                     'id' => $jim->id,
                     'name' => 'Dwight Schrute',
-                    'avatar' => ImageHelper::getAvatar($jim),
+                    'avatar' => ImageHelper::getAvatar($jim, 35),
                     'position' => $jim->position->title,
                     'url' => env('APP_URL').'/'.$jim->company_id.'/employees/'.$jim->id,
                     'entry' => [
@@ -213,7 +213,7 @@ class DashboardManagerViewHelperTest extends TestCase
                 0 => [
                     'id' => $dwight->id,
                     'name' => 'Dwight Schrute',
-                    'avatar' => ImageHelper::getAvatar($dwight),
+                    'avatar' => ImageHelper::getAvatar($dwight, 35),
                     'position' => $dwight->position->title,
                     'url' => env('APP_URL').'/'.$dwight->company_id.'/employees/'.$dwight->id,
                     'contract_information' => [

--- a/tests/Unit/ViewHelpers/Dashboard/DashboardMeViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Dashboard/DashboardMeViewHelperTest.php
@@ -263,7 +263,7 @@ class DashboardMeViewHelperTest extends TestCase
                 0 => [
                     'id' => $dwight->id,
                     'name' => 'Dwight Schrute',
-                    'avatar' => ImageHelper::getAvatar($dwight),
+                    'avatar' => ImageHelper::getAvatar($dwight, 35),
                     'position' => $dwight->position->title,
                     'url' => env('APP_URL').'/'.$dwight->company_id.'/employees/'.$dwight->id,
                     'entry' => [
@@ -274,7 +274,7 @@ class DashboardMeViewHelperTest extends TestCase
                 1 => [
                     'id' => $michael->id,
                     'name' => 'Dwight Schrute',
-                    'avatar' => ImageHelper::getAvatar($michael),
+                    'avatar' => ImageHelper::getAvatar($michael, 35),
                     'position' => $michael->position->title,
                     'url' => env('APP_URL').'/'.$michael->company_id.'/employees/'.$michael->id,
                     'entry' => [
@@ -388,7 +388,7 @@ class DashboardMeViewHelperTest extends TestCase
                     'id' => $match->employeeMatchedWith->id,
                     'name' => $match->employeeMatchedWith->name,
                     'first_name' => $match->employeeMatchedWith->first_name,
-                    'avatar' => ImageHelper::getAvatar($match->employeeMatchedWith),
+                    'avatar' => ImageHelper::getAvatar($match->employeeMatchedWith, 55),
                     'position' => $match->employeeMatchedWith->position ? $match->employeeMatchedWith->position->title : null,
                     'url' => env('APP_URL').'/'.$michael->company_id.'/employees/'.$match->employeeMatchedWith->id,
                     'teams' => null,

--- a/tests/Unit/ViewHelpers/Dashboard/DashboardOneOnOneViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Dashboard/DashboardOneOnOneViewHelperTest.php
@@ -47,7 +47,7 @@ class DashboardOneOnOneViewHelperTest extends TestCase
             [
                 'id' => $entry->employee->id,
                 'name' => $entry->employee->name,
-                'avatar' => ImageHelper::getAvatar($entry->employee),
+                'avatar' => ImageHelper::getAvatar($entry->employee, 22),
                 'url' => env('APP_URL').'/'.$michael->company_id.'/employees/'.$entry->employee->id,
             ],
             $array['employee']
@@ -56,7 +56,7 @@ class DashboardOneOnOneViewHelperTest extends TestCase
             [
                 'id' => $entry->manager->id,
                 'name' => $entry->manager->name,
-                'avatar' => ImageHelper::getAvatar($entry->manager),
+                'avatar' => ImageHelper::getAvatar($entry->manager, 22),
                 'url' => env('APP_URL').'/'.$michael->company_id.'/employees/'.$entry->manager->id,
             ],
             $array['manager']

--- a/tests/Unit/ViewHelpers/Dashboard/DashboardTeamViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Dashboard/DashboardTeamViewHelperTest.php
@@ -57,7 +57,7 @@ class DashboardTeamViewHelperTest extends TestCase
                 0 => [
                     'id' => $angela->id,
                     'name' => 'Angela Bernard',
-                    'avatar' => ImageHelper::getAvatar($angela),
+                    'avatar' => ImageHelper::getAvatar($angela, 35),
                     'url' => env('APP_URL').'/'.$angela->company_id.'/employees/'.$angela->id,
                     'birthdate' => 'January 5th',
                     'sort_key' => '2018-01-05',
@@ -65,7 +65,7 @@ class DashboardTeamViewHelperTest extends TestCase
                 1 => [
                     'id' => $dwight->id,
                     'name' => 'Dwight Schrute',
-                    'avatar' => ImageHelper::getAvatar($dwight),
+                    'avatar' => ImageHelper::getAvatar($dwight, 35),
                     'url' => env('APP_URL').'/'.$angela->company_id.'/employees/'.$dwight->id,
                     'birthdate' => 'January 29th',
                     'sort_key' => '2018-01-29',
@@ -119,7 +119,7 @@ class DashboardTeamViewHelperTest extends TestCase
                 0 => [
                     'id' => $dwight->id,
                     'name' => 'Dwight Schrute',
-                    'avatar' => ImageHelper::getAvatar($dwight),
+                    'avatar' => ImageHelper::getAvatar($dwight, 35),
                     'position' => $dwight->position,
                     'url' => env('APP_URL').'/'.$dwight->company_id.'/employees/'.$dwight->id,
                 ],
@@ -157,7 +157,7 @@ class DashboardTeamViewHelperTest extends TestCase
                         0 => [
                             'id' => $michael->id,
                             'name' => $michael->name,
-                            'avatar' => ImageHelper::getAvatar($michael),
+                            'avatar' => ImageHelper::getAvatar($michael, 17),
                             'url' => env('APP_URL').'/'.$michael->company_id.'/employees/'.$michael->id,
                         ],
                     ],
@@ -277,7 +277,7 @@ class DashboardTeamViewHelperTest extends TestCase
                 0 => [
                     'id' => $dwight->id,
                     'name' => $dwight->name,
-                    'avatar' => ImageHelper::getAvatar($dwight),
+                    'avatar' => ImageHelper::getAvatar($dwight, 35),
                     'hired_at' => 'Tuesday (Jan 2nd)',
                     'position' => (! $dwight->position) ? null : [
                         'id' => $dwight->position->id,
@@ -323,7 +323,7 @@ class DashboardTeamViewHelperTest extends TestCase
                 0 => [
                     'id' => $dwight->id,
                     'name' => $dwight->name,
-                    'avatar' => ImageHelper::getAvatar($dwight),
+                    'avatar' => ImageHelper::getAvatar($dwight, 35),
                     'anniversary_date' => 'Tuesday (Jan 2nd)',
                     'anniversary_age' => '28',
                     'url' => env('APP_URL').'/'.$michael->company_id.'/employees/'.$dwight->id,

--- a/tests/Unit/ViewHelpers/Dashboard/Manager/DashboardManagerTimesheetViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Dashboard/Manager/DashboardManagerTimesheetViewHelperTest.php
@@ -87,7 +87,7 @@ class DashboardManagerTimesheetViewHelperTest extends TestCase
             $collection->toArray()[0]['name']
         );
         $this->assertEquals(
-            ImageHelper::getAvatar($dwight),
+            ImageHelper::getAvatar($dwight, 35),
             $collection->toArray()[0]['avatar']
         );
         $this->assertEquals(

--- a/tests/Unit/ViewHelpers/Employee/EmployeeECoffeeViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Employee/EmployeeECoffeeViewHelperTest.php
@@ -59,7 +59,7 @@ class EmployeeECoffeeViewHelperTest extends TestCase
                     'id' => $dwight->id,
                     'name' => $dwight->name,
                     'first_name' => $dwight->first_name,
-                    'avatar' => ImageHelper::getAvatar($dwight),
+                    'avatar' => ImageHelper::getAvatar($dwight, 35),
                     'position' => $dwight->position ? $dwight->position->title : null,
                     'url' => env('APP_URL').'/'.$michael->company_id.'/employees/'.$dwight->id,
                 ],

--- a/tests/Unit/ViewHelpers/Employee/EmployeeLogViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Employee/EmployeeLogViewHelperTest.php
@@ -36,12 +36,27 @@ class EmployeeLogViewHelperTest extends TestCase
                 'author' => [
                     'id' => $michael->id,
                     'name' => 'michael scott',
-                    'avatar' => ImageHelper::getAvatar($michael),
+                    'avatar' => ImageHelper::getAvatar($michael, 34),
                     'url' => env('APP_URL').'/'.$michael->company_id.'/employees/'.$michael->id,
                 ],
                 'localized_audited_at' => 'Jan 12, 2020 00:00',
             ],
             EmployeeLogViewHelper::list($logs, $michael->company)->toArray()[0]
+        );
+    }
+
+    /** @test */
+    public function it_gets_the_information_about_the_employee(): void
+    {
+        $michael = Employee::factory()->create();
+
+        $this->assertEquals(
+            [
+                'id' => $michael->id,
+                'name' => $michael->name,
+                'avatar' => ImageHelper::getAvatar($michael, 80),
+            ],
+            EmployeeLogViewHelper::employee($michael)
         );
     }
 }

--- a/tests/Unit/ViewHelpers/Employee/EmployeeOneOnOneViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Employee/EmployeeOneOnOneViewHelperTest.php
@@ -92,7 +92,7 @@ class EmployeeOneOnOneViewHelperTest extends TestCase
                     'manager' => [
                         'id' => $michael->id,
                         'name' => $michael->name,
-                        'avatar' => ImageHelper::getAvatar($michael),
+                        'avatar' => ImageHelper::getAvatar($michael, 22),
                         'url' => env('APP_URL').'/'.$michael->company_id.'/employees/'.$michael->id,
                     ],
                     'url' => env('APP_URL').'/'.$michael->company_id.'/employees/'.$dwight->id.'/performance/oneonones/'.$entry2019->id,
@@ -106,7 +106,7 @@ class EmployeeOneOnOneViewHelperTest extends TestCase
                     'manager' => [
                         'id' => $michael->id,
                         'name' => $michael->name,
-                        'avatar' => ImageHelper::getAvatar($michael),
+                        'avatar' => ImageHelper::getAvatar($michael, 22),
                         'url' => env('APP_URL').'/'.$michael->company_id.'/employees/'.$michael->id,
                     ],
                     'url' => env('APP_URL').'/'.$michael->company_id.'/employees/'.$dwight->id.'/performance/oneonones/'.$entry2018->id,
@@ -120,7 +120,7 @@ class EmployeeOneOnOneViewHelperTest extends TestCase
                     'manager' => [
                         'id' => $michael->id,
                         'name' => $michael->name,
-                        'avatar' => ImageHelper::getAvatar($michael),
+                        'avatar' => ImageHelper::getAvatar($michael, 22),
                         'url' => env('APP_URL').'/'.$michael->company_id.'/employees/'.$michael->id,
                     ],
                     'url' => env('APP_URL').'/'.$michael->company_id.'/employees/'.$dwight->id.'/performance/oneonones/'.$entry2017->id,
@@ -162,7 +162,7 @@ class EmployeeOneOnOneViewHelperTest extends TestCase
             [
                 'id' => $entry->employee->id,
                 'name' => $entry->employee->name,
-                'avatar' => ImageHelper::getAvatar($entry->employee),
+                'avatar' => ImageHelper::getAvatar($entry->employee, 22),
                 'url' => env('APP_URL').'/'.$michael->company_id.'/employees/'.$entry->employee->id,
             ],
             $array['employee']
@@ -171,7 +171,7 @@ class EmployeeOneOnOneViewHelperTest extends TestCase
             [
                 'id' => $entry->manager->id,
                 'name' => $entry->manager->name,
-                'avatar' => ImageHelper::getAvatar($entry->manager),
+                'avatar' => ImageHelper::getAvatar($entry->manager, 22),
                 'url' => env('APP_URL').'/'.$michael->company_id.'/employees/'.$entry->manager->id,
             ],
             $array['manager']

--- a/tests/Unit/ViewHelpers/Employee/EmployeeShowViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Employee/EmployeeShowViewHelperTest.php
@@ -117,7 +117,7 @@ class EmployeeShowViewHelperTest extends TestCase
                 0 => [
                     'id' => $michael->id,
                     'name' => $michael->name,
-                    'avatar' => ImageHelper::getAvatar($michael),
+                    'avatar' => ImageHelper::getAvatar($michael, 35),
                     'position' => [
                         'id' => $michael->position->id,
                         'title' => $michael->position->title,
@@ -127,7 +127,7 @@ class EmployeeShowViewHelperTest extends TestCase
                 1 => [
                     'id' => $jim->id,
                     'name' => $jim->name,
-                    'avatar' => ImageHelper::getAvatar($jim),
+                    'avatar' => ImageHelper::getAvatar($jim, 35),
                     'position' => [
                         'id' => $jim->position->id,
                         'title' => $jim->position->title,
@@ -173,7 +173,7 @@ class EmployeeShowViewHelperTest extends TestCase
                 0 => [
                     'id' => $dwight->id,
                     'name' => $dwight->name,
-                    'avatar' => ImageHelper::getAvatar($dwight),
+                    'avatar' => ImageHelper::getAvatar($dwight, 35),
                     'position' => [
                         'id' => $dwight->position->id,
                         'title' => $dwight->position->title,
@@ -183,7 +183,7 @@ class EmployeeShowViewHelperTest extends TestCase
                 1 => [
                     'id' => $jim->id,
                     'name' => $jim->name,
-                    'avatar' => ImageHelper::getAvatar($jim),
+                    'avatar' => ImageHelper::getAvatar($jim, 35),
                     'position' => [
                         'id' => $jim->position->id,
                         'title' => $jim->position->title,
@@ -511,7 +511,7 @@ class EmployeeShowViewHelperTest extends TestCase
                     'manager' => [
                         'id' => $michael->id,
                         'name' => $michael->name,
-                        'avatar' => ImageHelper::getAvatar($michael),
+                        'avatar' => ImageHelper::getAvatar($michael, 18),
                         'url' => env('APP_URL').'/'.$michael->company_id.'/employees/'.$michael->id,
                     ],
                     'url' => env('APP_URL').'/'.$michael->company_id.'/employees/'.$dwight->id.'/performance/oneonones/'.$entry2019->id,
@@ -522,7 +522,7 @@ class EmployeeShowViewHelperTest extends TestCase
                     'manager' => [
                         'id' => $michael->id,
                         'name' => $michael->name,
-                        'avatar' => ImageHelper::getAvatar($michael),
+                        'avatar' => ImageHelper::getAvatar($michael, 18),
                         'url' => env('APP_URL').'/'.$michael->company_id.'/employees/'.$michael->id,
                     ],
                     'url' => env('APP_URL').'/'.$michael->company_id.'/employees/'.$dwight->id.'/performance/oneonones/'.$entry2018->id,
@@ -533,7 +533,7 @@ class EmployeeShowViewHelperTest extends TestCase
                     'manager' => [
                         'id' => $michael->id,
                         'name' => $michael->name,
-                        'avatar' => ImageHelper::getAvatar($michael),
+                        'avatar' => ImageHelper::getAvatar($michael, 18),
                         'url' => env('APP_URL').'/'.$michael->company_id.'/employees/'.$michael->id,
                     ],
                     'url' => env('APP_URL').'/'.$michael->company_id.'/employees/'.$dwight->id.'/performance/oneonones/'.$entry2017->id,
@@ -785,7 +785,7 @@ class EmployeeShowViewHelperTest extends TestCase
                     'id' => $dwight->id,
                     'name' => $dwight->name,
                     'first_name' => $dwight->first_name,
-                    'avatar' => ImageHelper::getAvatar($dwight),
+                    'avatar' => ImageHelper::getAvatar($dwight, 35),
                     'position' => $dwight->position ? $dwight->position->title : null,
                     'url' => env('APP_URL').'/'.$michael->company_id.'/employees/'.$dwight->id,
                 ],

--- a/tests/Unit/ViewHelpers/Employee/EmployeeSurveysViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Employee/EmployeeSurveysViewHelperTest.php
@@ -223,19 +223,19 @@ class EmployeeSurveysViewHelperTest extends TestCase
                 0 => [
                     'id' => $answer1->employee->id,
                     'name' => $answer1->employee->name,
-                    'avatar' => ImageHelper::getAvatar($answer1->employee),
+                    'avatar' => ImageHelper::getAvatar($answer1->employee, 22),
                     'url' => env('APP_URL').'/'.$answer1->employee->company_id.'/employees/'.$answer1->employee->id,
                 ],
                 1 => [
                     'id' => $answer2->employee->id,
                     'name' => $answer2->employee->name,
-                    'avatar' => ImageHelper::getAvatar($answer2->employee),
+                    'avatar' => ImageHelper::getAvatar($answer2->employee, 22),
                     'url' => env('APP_URL').'/'.$answer2->employee->company_id.'/employees/'.$answer2->employee->id,
                 ],
                 2 => [
                     'id' => $answer3->employee->id,
                     'name' => $answer3->employee->name,
-                    'avatar' => ImageHelper::getAvatar($answer3->employee),
+                    'avatar' => ImageHelper::getAvatar($answer3->employee, 22),
                     'url' => env('APP_URL').'/'.$answer3->employee->company_id.'/employees/'.$answer3->employee->id,
                 ],
             ],

--- a/tests/Unit/ViewHelpers/Team/TeamIndexViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Team/TeamIndexViewHelperTest.php
@@ -43,13 +43,13 @@ class TeamIndexViewHelperTest extends TestCase
                 0 => [
                     'id' => $michael->id,
                     'name' => $michael->name,
-                    'avatar' => ImageHelper::getAvatar($michael),
+                    'avatar' => ImageHelper::getAvatar($michael, 20),
                     'url' => env('APP_URL').'/'.$michael->company_id.'/employees/'.$michael->id,
                 ],
                 1 => [
                     'id' => $dwight->id,
                     'name' => $dwight->name,
-                    'avatar' => ImageHelper::getAvatar($dwight),
+                    'avatar' => ImageHelper::getAvatar($dwight, 20),
                     'url' => env('APP_URL').'/'.$dwight->company_id.'/employees/'.$dwight->id,
                 ],
             ],

--- a/tests/Unit/ViewHelpers/Team/TeamMembersViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Team/TeamMembersViewHelperTest.php
@@ -49,7 +49,7 @@ class TeamMembersViewHelperTest extends TestCase
             [
                 'id' => $michael->id,
                 'name' => $michael->name,
-                'avatar' => ImageHelper::getAvatar($michael),
+                'avatar' => ImageHelper::getAvatar($michael, 35),
                 'position' => $michael->position,
             ],
             $array

--- a/tests/Unit/ViewHelpers/Team/TeamRecentShipViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Team/TeamRecentShipViewHelperTest.php
@@ -54,7 +54,7 @@ class TeamRecentShipViewHelperTest extends TestCase
                         0 => [
                             'id' => $michael->id,
                             'name' => $michael->name,
-                            'avatar' => ImageHelper::getAvatar($michael),
+                            'avatar' => ImageHelper::getAvatar($michael, 21),
                             'url' => env('APP_URL').'/'.$michael->company_id.'/employees/'.$michael->id,
                         ],
                     ],
@@ -97,7 +97,7 @@ class TeamRecentShipViewHelperTest extends TestCase
                     0 => [
                         'id' => $michael->id,
                         'name' => $michael->name,
-                        'avatar' => ImageHelper::getAvatar($michael),
+                        'avatar' => ImageHelper::getAvatar($michael, 44),
                         'position' => [
                             'title' => $michael->position->title,
                         ],

--- a/tests/Unit/ViewHelpers/Team/TeamShowViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Team/TeamShowViewHelperTest.php
@@ -42,7 +42,7 @@ class TeamShowViewHelperTest extends TestCase
                 0 => [
                     'id' => $michael->id,
                     'name' => $michael->name,
-                    'avatar' => ImageHelper::getAvatar($michael),
+                    'avatar' => ImageHelper::getAvatar($michael, 35),
                     'position' => [
                         'id' => $michael->position->id,
                         'title' => $michael->position->title,
@@ -52,7 +52,7 @@ class TeamShowViewHelperTest extends TestCase
                 1 => [
                     'id' => $dwight->id,
                     'name' => $dwight->name,
-                    'avatar' => ImageHelper::getAvatar($dwight),
+                    'avatar' => ImageHelper::getAvatar($dwight, 35),
                     'position' => [
                         'id' => $dwight->position->id,
                         'title' => $dwight->position->title,
@@ -92,7 +92,7 @@ class TeamShowViewHelperTest extends TestCase
                         0 => [
                             'id' => $michael->id,
                             'name' => $michael->name,
-                            'avatar' => ImageHelper::getAvatar($michael),
+                            'avatar' => ImageHelper::getAvatar($michael, 17),
                             'url' => env('APP_URL').'/'.$michael->company_id.'/employees/'.$michael->id,
                         ],
                     ],


### PR DESCRIPTION
The current avatar are not "retina ready", ie high definition.

This PR brings the `srcset` attribute to a new Avatar component that scales the image to the right width when displayed on a retina screen.

Example:

<img width="430" alt="image" src="https://user-images.githubusercontent.com/61099/111891215-9f5b7380-89c7-11eb-85a1-7a8aef847774.png">
