### PR TITLE
refactor: remove title from the layout vue file

### DIFF
--- a/resources/js/Pages/Adminland/Audit/Index.vue
+++ b/resources/js/Pages/Adminland/Audit/Index.vue
@@ -5,7 +5,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Adminland/CompanyNews/Create.vue
+++ b/resources/js/Pages/Adminland/CompanyNews/Create.vue
@@ -8,7 +8,7 @@ input[type=radio] {
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Adminland/CompanyNews/Edit.vue
+++ b/resources/js/Pages/Adminland/CompanyNews/Edit.vue
@@ -8,7 +8,7 @@ input[type=radio] {
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Adminland/CompanyNews/Index.vue
+++ b/resources/js/Pages/Adminland/CompanyNews/Index.vue
@@ -13,7 +13,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Adminland/CompanyPTOPolicy/Index.vue
+++ b/resources/js/Pages/Adminland/CompanyPTOPolicy/Index.vue
@@ -38,7 +38,7 @@ td, th {
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Adminland/ECoffee/Index.vue
+++ b/resources/js/Pages/Adminland/ECoffee/Index.vue
@@ -22,7 +22,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Adminland/Employee/Archives/Index.vue
+++ b/resources/js/Pages/Adminland/Employee/Archives/Index.vue
@@ -40,7 +40,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Adminland/Employee/Archives/Show.vue
+++ b/resources/js/Pages/Adminland/Employee/Archives/Show.vue
@@ -39,7 +39,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Adminland/Employee/Create.vue
+++ b/resources/js/Pages/Adminland/Employee/Create.vue
@@ -8,7 +8,7 @@ input[type=radio] {
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Adminland/Employee/Delete.vue
+++ b/resources/js/Pages/Adminland/Employee/Delete.vue
@@ -2,7 +2,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Adminland/Employee/Import.vue
+++ b/resources/js/Pages/Adminland/Employee/Import.vue
@@ -9,7 +9,7 @@ input[type=radio] {
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Adminland/Employee/Index.vue
+++ b/resources/js/Pages/Adminland/Employee/Index.vue
@@ -7,7 +7,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Adminland/Employee/IndexActive.vue
+++ b/resources/js/Pages/Adminland/Employee/IndexActive.vue
@@ -1,5 +1,5 @@
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Adminland/Employee/IndexAll.vue
+++ b/resources/js/Pages/Adminland/Employee/IndexAll.vue
@@ -1,5 +1,5 @@
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Adminland/Employee/IndexLocked.vue
+++ b/resources/js/Pages/Adminland/Employee/IndexLocked.vue
@@ -1,5 +1,5 @@
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Adminland/Employee/IndexNoHiringDate.vue
+++ b/resources/js/Pages/Adminland/Employee/IndexNoHiringDate.vue
@@ -1,5 +1,5 @@
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Adminland/Employee/Lock.vue
+++ b/resources/js/Pages/Adminland/Employee/Lock.vue
@@ -2,7 +2,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Adminland/Employee/Unlock.vue
+++ b/resources/js/Pages/Adminland/Employee/Unlock.vue
@@ -2,7 +2,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Adminland/EmployeeStatus/Index.vue
+++ b/resources/js/Pages/Adminland/EmployeeStatus/Index.vue
@@ -29,7 +29,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Adminland/Expense/Index.vue
+++ b/resources/js/Pages/Adminland/Expense/Index.vue
@@ -5,7 +5,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Adminland/Flow/Create.vue
+++ b/resources/js/Pages/Adminland/Flow/Create.vue
@@ -19,7 +19,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Adminland/Flow/Index.vue
+++ b/resources/js/Pages/Adminland/Flow/Index.vue
@@ -1,5 +1,5 @@
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Adminland/Flow/Show.vue
+++ b/resources/js/Pages/Adminland/Flow/Show.vue
@@ -1,5 +1,5 @@
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Adminland/General/Cancel/Index.vue
+++ b/resources/js/Pages/Adminland/General/Cancel/Index.vue
@@ -7,7 +7,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Adminland/General/Index.vue
+++ b/resources/js/Pages/Adminland/General/Index.vue
@@ -2,7 +2,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Adminland/Hardware/Create.vue
+++ b/resources/js/Pages/Adminland/Hardware/Create.vue
@@ -8,7 +8,7 @@ input[type=radio] {
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Adminland/Hardware/Edit.vue
+++ b/resources/js/Pages/Adminland/Hardware/Edit.vue
@@ -8,7 +8,7 @@ input[type=radio] {
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Adminland/Hardware/Index.vue
+++ b/resources/js/Pages/Adminland/Hardware/Index.vue
@@ -33,7 +33,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Adminland/Hardware/Show.vue
+++ b/resources/js/Pages/Adminland/Hardware/Show.vue
@@ -16,7 +16,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Adminland/Index.vue
+++ b/resources/js/Pages/Adminland/Index.vue
@@ -19,7 +19,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Adminland/Position/Index.vue
+++ b/resources/js/Pages/Adminland/Position/Index.vue
@@ -5,7 +5,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Adminland/Question/Index.vue
+++ b/resources/js/Pages/Adminland/Question/Index.vue
@@ -15,7 +15,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Adminland/Team/Index.vue
+++ b/resources/js/Pages/Adminland/Team/Index.vue
@@ -36,7 +36,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Adminland/Team/Logs.vue
+++ b/resources/js/Pages/Adminland/Team/Logs.vue
@@ -5,7 +5,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Auth/Invitation/AcceptInvitation.vue
+++ b/resources/js/Pages/Auth/Invitation/AcceptInvitation.vue
@@ -1,5 +1,5 @@
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <div class="cf mw6 center br3 mb3 bg-white box">
         <div class="pa3">

--- a/resources/js/Pages/Auth/VerifyEmail.vue
+++ b/resources/js/Pages/Auth/VerifyEmail.vue
@@ -15,7 +15,7 @@
 </style>
 
 <template>
-  <layout title="Home" :no-menu="true" :notifications="notifications">
+  <layout :no-menu="true" :notifications="notifications">
     <div class="ph2 ph0-ns">
       <div class="cf mt4 mw7 center br3 mb3 bg-white box">
         <div class="pa3 tc">

--- a/resources/js/Pages/Company/HR/Index.vue
+++ b/resources/js/Pages/Company/HR/Index.vue
@@ -33,7 +33,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <!-- company cover -->
     <div class="cover mb3" :style="'height: 25vh; background: url(https://images.unsplash.com/photo-1531973576160-7125cd663d86?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1500&q=80) no-repeat center center'"></div>
 

--- a/resources/js/Pages/Company/Index.vue
+++ b/resources/js/Pages/Company/Index.vue
@@ -10,7 +10,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <!-- company cover -->
     <div class="cover mb3" :style="'height: 25vh; background: url(https://images.unsplash.com/photo-1531973576160-7125cd663d86?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1500&q=80) no-repeat center center'"></div>
 

--- a/resources/js/Pages/Company/News/Index.vue
+++ b/resources/js/Pages/Company/News/Index.vue
@@ -7,7 +7,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Company/Project/Create.vue
+++ b/resources/js/Pages/Company/Project/Create.vue
@@ -29,7 +29,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Company/Project/CreateStatus.vue
+++ b/resources/js/Pages/Company/Project/CreateStatus.vue
@@ -9,7 +9,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Company/Project/Decisions/Index.vue
+++ b/resources/js/Pages/Company/Project/Decisions/Index.vue
@@ -46,7 +46,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph5-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mb4 mw6 br3 center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Company/Project/Delete.vue
+++ b/resources/js/Pages/Company/Project/Delete.vue
@@ -1,5 +1,5 @@
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Company/Project/Edit.vue
+++ b/resources/js/Pages/Company/Project/Edit.vue
@@ -1,5 +1,5 @@
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Company/Project/Files/Index.vue
+++ b/resources/js/Pages/Company/Project/Files/Index.vue
@@ -9,7 +9,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph5-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mb4 mw6 br3 center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Company/Project/Index.vue
+++ b/resources/js/Pages/Company/Project/Index.vue
@@ -41,7 +41,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <!-- company cover -->
     <div class="cover mb3" :style="'height: 25vh; background: url(https://images.unsplash.com/photo-1531973576160-7125cd663d86?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1500&q=80) no-repeat center center'"></div>
 

--- a/resources/js/Pages/Company/Project/Members/Index.vue
+++ b/resources/js/Pages/Company/Project/Members/Index.vue
@@ -40,7 +40,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph5-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mb4 mw6 br3 center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Company/Project/Messages/Create.vue
+++ b/resources/js/Pages/Company/Project/Messages/Create.vue
@@ -7,7 +7,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Company/Project/Messages/Index.vue
+++ b/resources/js/Pages/Company/Project/Messages/Index.vue
@@ -27,7 +27,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph5-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mb4 mw6 br3 center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Company/Project/Messages/Show.vue
+++ b/resources/js/Pages/Company/Project/Messages/Show.vue
@@ -29,7 +29,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph5-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mb4 mw6 br3 center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Company/Project/Messages/Update.vue
+++ b/resources/js/Pages/Company/Project/Messages/Update.vue
@@ -7,7 +7,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Company/Project/Show.vue
+++ b/resources/js/Pages/Company/Project/Show.vue
@@ -11,7 +11,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph5-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mb4 mw6 br3 center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Company/Project/Tasks/Index.vue
+++ b/resources/js/Pages/Company/Project/Tasks/Index.vue
@@ -14,7 +14,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph5-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mb4 mw6 br3 center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Company/Project/Tasks/Show.vue
+++ b/resources/js/Pages/Company/Project/Tasks/Show.vue
@@ -58,7 +58,7 @@ input[type=checkbox] {
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph5-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mb4 mw6 br3 center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Company/Question/Index.vue
+++ b/resources/js/Pages/Company/Question/Index.vue
@@ -6,7 +6,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Company/Question/Show.vue
+++ b/resources/js/Pages/Company/Question/Show.vue
@@ -10,7 +10,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Company/Skill/Index.vue
+++ b/resources/js/Pages/Company/Skill/Index.vue
@@ -25,7 +25,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Company/Skill/Show.vue
+++ b/resources/js/Pages/Company/Skill/Show.vue
@@ -38,7 +38,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Dashboard/Expenses/Approve.vue
+++ b/resources/js/Pages/Dashboard/Expenses/Approve.vue
@@ -5,7 +5,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Dashboard/Expenses/Index.vue
+++ b/resources/js/Pages/Dashboard/Expenses/Index.vue
@@ -42,7 +42,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <dashboard-menu :employee="employee" />
 

--- a/resources/js/Pages/Dashboard/Expenses/Show.vue
+++ b/resources/js/Pages/Dashboard/Expenses/Show.vue
@@ -5,7 +5,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Dashboard/HR/Index.vue
+++ b/resources/js/Pages/Dashboard/HR/Index.vue
@@ -6,7 +6,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <dashboard-menu :employee="employee" />
     </div>

--- a/resources/js/Pages/Dashboard/HR/Timesheets/Index.vue
+++ b/resources/js/Pages/Dashboard/HR/Timesheets/Index.vue
@@ -36,7 +36,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Dashboard/HR/Timesheets/Show.vue
+++ b/resources/js/Pages/Dashboard/HR/Timesheets/Show.vue
@@ -31,7 +31,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Dashboard/Manager/ApproveExpense.vue
+++ b/resources/js/Pages/Dashboard/Manager/ApproveExpense.vue
@@ -5,7 +5,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Dashboard/Manager/Index.vue
+++ b/resources/js/Pages/Dashboard/Manager/Index.vue
@@ -6,7 +6,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <dashboard-menu :employee="employee" />
     </div>

--- a/resources/js/Pages/Dashboard/Manager/Timesheets/Index.vue
+++ b/resources/js/Pages/Dashboard/Manager/Timesheets/Index.vue
@@ -36,7 +36,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Dashboard/Manager/Timesheets/Show.vue
+++ b/resources/js/Pages/Dashboard/Manager/Timesheets/Show.vue
@@ -31,7 +31,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Dashboard/Me/Index.vue
+++ b/resources/js/Pages/Dashboard/Me/Index.vue
@@ -6,7 +6,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <dashboard-menu :employee="employee" />
 

--- a/resources/js/Pages/Dashboard/OneOnOnes/Show.vue
+++ b/resources/js/Pages/Dashboard/OneOnOnes/Show.vue
@@ -39,7 +39,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Dashboard/Team/Index.vue
+++ b/resources/js/Pages/Dashboard/Team/Index.vue
@@ -15,7 +15,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <dashboard-menu :employee="employee" />
 

--- a/resources/js/Pages/Dashboard/Team/Partials/MyTeamEmptyState.vue
+++ b/resources/js/Pages/Dashboard/Team/Partials/MyTeamEmptyState.vue
@@ -1,5 +1,5 @@
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <div class="cf mt4 mw7 center">
         <h2 class="tc fw5">

--- a/resources/js/Pages/Dashboard/Timesheet/Index.vue
+++ b/resources/js/Pages/Dashboard/Timesheet/Index.vue
@@ -46,7 +46,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <dashboard-menu :employee="employee" />
 

--- a/resources/js/Pages/Employee/Administration/Expenses/Index.vue
+++ b/resources/js/Pages/Employee/Administration/Expenses/Index.vue
@@ -36,7 +36,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Employee/Administration/Expenses/Show.vue
+++ b/resources/js/Pages/Employee/Administration/Expenses/Show.vue
@@ -5,7 +5,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Employee/Administration/Index.vue
+++ b/resources/js/Pages/Employee/Administration/Index.vue
@@ -7,7 +7,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph5-ns mt4">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw7 br3 center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Employee/Administration/Timesheets/Index.vue
+++ b/resources/js/Pages/Employee/Administration/Timesheets/Index.vue
@@ -55,7 +55,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Employee/Administration/Timesheets/Show.vue
+++ b/resources/js/Pages/Employee/Administration/Timesheets/Show.vue
@@ -31,7 +31,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Employee/ECoffee/Index.vue
+++ b/resources/js/Pages/Employee/ECoffee/Index.vue
@@ -12,7 +12,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Employee/Edit.vue
+++ b/resources/js/Pages/Employee/Edit.vue
@@ -8,7 +8,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Employee/Edit/Address.vue
+++ b/resources/js/Pages/Employee/Edit/Address.vue
@@ -8,7 +8,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Employee/Edit/Contract.vue
+++ b/resources/js/Pages/Employee/Edit/Contract.vue
@@ -21,7 +21,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Employee/Index.vue
+++ b/resources/js/Pages/Employee/Index.vue
@@ -5,7 +5,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph5-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Employee/Logs/Index.vue
+++ b/resources/js/Pages/Employee/Logs/Index.vue
@@ -20,7 +20,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Employee/Performance/Index.vue
+++ b/resources/js/Pages/Employee/Performance/Index.vue
@@ -16,7 +16,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph5-ns mt4">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw7 br3 center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Employee/Performance/OneOnOnes/Index.vue
+++ b/resources/js/Pages/Employee/Performance/OneOnOnes/Index.vue
@@ -13,7 +13,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Employee/Performance/OneOnOnes/Show.vue
+++ b/resources/js/Pages/Employee/Performance/OneOnOnes/Show.vue
@@ -39,7 +39,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Employee/Performance/Surveys/Index.vue
+++ b/resources/js/Pages/Employee/Performance/Surveys/Index.vue
@@ -13,7 +13,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Employee/Performance/Surveys/Show.vue
+++ b/resources/js/Pages/Employee/Performance/Surveys/Show.vue
@@ -9,7 +9,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Employee/Show.vue
+++ b/resources/js/Pages/Employee/Show.vue
@@ -7,7 +7,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph5-ns mt4">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw7 br3 center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Employee/Work/Index.vue
+++ b/resources/js/Pages/Employee/Work/Index.vue
@@ -7,7 +7,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph5-ns mt4">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw7 br3 center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Employee/Work/WorkFromHome/Index.vue
+++ b/resources/js/Pages/Employee/Work/WorkFromHome/Index.vue
@@ -20,7 +20,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Employee/Work/Worklogs/Index.vue
+++ b/resources/js/Pages/Employee/Work/Worklogs/Index.vue
@@ -20,7 +20,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Home/CreateCompany.vue
+++ b/resources/js/Pages/Home/CreateCompany.vue
@@ -4,7 +4,7 @@ img {
 }
 </style>
 <template>
-  <layout title="Home" :no-menu="true" :notifications="notifications">
+  <layout :no-menu="true" :notifications="notifications">
     <div class="ph2 ph0-ns">
       <div class="mt4 mw6 center mb1">
         <p class="mt0 mb3 f6">← <inertia-link :href="'/'">{{ $t('app.back') }}</inertia-link></p>

--- a/resources/js/Pages/Home/Index.vue
+++ b/resources/js/Pages/Home/Index.vue
@@ -35,7 +35,7 @@
 </style>
 
 <template>
-  <layout title="Home" :no-menu="true" :notifications="notifications">
+  <layout :no-menu="true" :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- Blank state -->
       <div v-show="employees.length == 0" class="cf mt4 mt5-l mw7 center">

--- a/resources/js/Pages/Notification/Index.vue
+++ b/resources/js/Pages/Notification/Index.vue
@@ -5,7 +5,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph5-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Team/Index.vue
+++ b/resources/js/Pages/Team/Index.vue
@@ -7,7 +7,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph5-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 center breadcrumb relative z-0 f6 pb2" :class="{'bg-white box': teams.length == 0}">

--- a/resources/js/Pages/Team/Ship/Create.vue
+++ b/resources/js/Pages/Team/Ship/Create.vue
@@ -28,7 +28,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Team/Ship/Index.vue
+++ b/resources/js/Pages/Team/Ship/Index.vue
@@ -17,7 +17,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Team/Ship/Show.vue
+++ b/resources/js/Pages/Team/Ship/Show.vue
@@ -28,7 +28,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Team/Show.vue
+++ b/resources/js/Pages/Team/Show.vue
@@ -20,7 +20,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph5-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mb3 mw7 br3 center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Team/TeamNews/Create.vue
+++ b/resources/js/Pages/Team/TeamNews/Create.vue
@@ -8,7 +8,7 @@ input[type=radio] {
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Team/TeamNews/Edit.vue
+++ b/resources/js/Pages/Team/TeamNews/Edit.vue
@@ -8,7 +8,7 @@ input[type=radio] {
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Team/TeamNews/Index.vue
+++ b/resources/js/Pages/Team/TeamNews/Index.vue
@@ -8,7 +8,7 @@
 </style>
 
 <template>
-  <layout title="Home" :notifications="notifications">
+  <layout :notifications="notifications">
     <div class="ph2 ph0-ns">
       <!-- BREADCRUMB -->
       <div class="mt4-l mt1 mw6 br3 bg-white box center breadcrumb relative z-0 f6 pb2">

--- a/resources/js/Pages/Welcome/Index.vue
+++ b/resources/js/Pages/Welcome/Index.vue
@@ -6,7 +6,7 @@
 </style>
 
 <template>
-  <layout title="Home" :show-help-on-page="false" :notifications="notifications" data-cy="company-welcome" :data-cy-item="$page.props.auth.company.id">
+  <layout :show-help-on-page="false" :notifications="notifications" data-cy="company-welcome" :data-cy-item="$page.props.auth.company.id">
     <div class="ph2 ph0-ns">
       <!-- toggle button -->
       <p class="mt3 tc f6"><span class="mr1">🙈</span><a data-cy="hide-message" href="#" class="mb2" @click.prevent="hide()">{{ $t('welcome.hide_message_forever') }}</a></p>


### PR DESCRIPTION
The main Layout vue file contains a `title` attribute, that we can use if we want to customize the title of the tab in the browser.

Right now, it was set to `Home` for every page. This PR removes it so it's cleaner.