### PR TITLE
feat: record member activity in a project

### DIFF
--- a/app/Console/Commands/Tests/SetupDummyAccount.php
+++ b/app/Console/Commands/Tests/SetupDummyAccount.php
@@ -52,8 +52,8 @@ use App\Services\Company\Adminland\Question\CreateQuestion;
 use App\Services\Company\Employee\HiringDate\SetHiringDate;
 use App\Services\Company\Employee\Timesheet\RejectTimesheet;
 use App\Services\Company\Employee\Timesheet\SubmitTimesheet;
-use App\Services\Company\Project\AssignProjecTaskToEmployee;
 use App\Services\Company\Employee\Timesheet\ApproveTimesheet;
+use App\Services\Company\Project\AssignProjectTaskToEmployee;
 use App\Services\Company\Team\Description\SetTeamDescription;
 use App\Services\Company\Employee\OneOnOne\CreateOneOnOneNote;
 use App\Services\Company\Employee\Skill\AttachEmployeeToSkill;
@@ -1805,7 +1805,7 @@ Creed dyes his hair jet-black (using ink cartridges) in an attempt to convince e
             'title' => 'Migrate domain names when the new site launches',
             'description' => null,
         ]);
-        (new AssignProjecTaskToEmployee)->execute([
+        (new AssignProjectTaskToEmployee)->execute([
             'company_id' => $this->company->id,
             'author_id' => $this->meredith->id,
             'project_id' => $this->projectInfinity->id,
@@ -1828,7 +1828,7 @@ Creed dyes his hair jet-black (using ink cartridges) in an attempt to convince e
             'title' => 'Make sure the SEO is implemented',
             'description' => null,
         ]);
-        (new AssignProjecTaskToEmployee)->execute([
+        (new AssignProjectTaskToEmployee)->execute([
             'company_id' => $this->company->id,
             'author_id' => $this->jim->id,
             'project_id' => $this->projectInfinity->id,
@@ -1851,7 +1851,7 @@ Creed dyes his hair jet-black (using ink cartridges) in an attempt to convince e
             'title' => 'Migrate the ACLs',
             'description' => null,
         ]);
-        (new AssignProjecTaskToEmployee)->execute([
+        (new AssignProjectTaskToEmployee)->execute([
             'company_id' => $this->company->id,
             'author_id' => $this->meredith->id,
             'project_id' => $this->projectInfinity->id,
@@ -1874,7 +1874,7 @@ Creed dyes his hair jet-black (using ink cartridges) in an attempt to convince e
             'title' => 'Take appointment with the photographer',
             'description' => 'We need to make sure all photos look great if possible',
         ]);
-        (new AssignProjecTaskToEmployee)->execute([
+        (new AssignProjectTaskToEmployee)->execute([
             'company_id' => $this->company->id,
             'author_id' => $this->michael->id,
             'project_id' => $this->projectInfinity->id,

--- a/app/Http/Controllers/Company/Company/Project/ProjectTasksController.php
+++ b/app/Http/Controllers/Company/Company/Project/ProjectTasksController.php
@@ -21,7 +21,7 @@ use App\Services\Company\Project\UpdateProjectTask;
 use App\Services\Company\Project\DestroyProjectTask;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use App\Http\ViewHelpers\Company\Project\ProjectViewHelper;
-use App\Services\Company\Project\AssignProjecTaskToEmployee;
+use App\Services\Company\Project\AssignProjectTaskToEmployee;
 use App\Http\ViewHelpers\Company\Project\ProjectTasksViewHelper;
 use App\Services\Company\Employee\Timesheet\CreateTimeTrackingEntry;
 
@@ -121,7 +121,7 @@ class ProjectTasksController extends Controller
         $task = (new CreateProjectTask)->execute($data);
 
         if ($request->input('assignee_id')) {
-            $task = (new AssignProjecTaskToEmployee)->execute([
+            $task = (new AssignProjectTaskToEmployee)->execute([
                 'company_id' => $company->id,
                 'author_id' => $loggedEmployee->id,
                 'project_id' => $projectId,
@@ -181,7 +181,7 @@ class ProjectTasksController extends Controller
         $task = (new UpdateProjectTask)->execute($data);
 
         if ($request->input('assignee_id')) {
-            $task = (new AssignProjecTaskToEmployee)->execute([
+            $task = (new AssignProjectTaskToEmployee)->execute([
                 'company_id' => $company->id,
                 'author_id' => $loggedEmployee->id,
                 'project_id' => $projectId,

--- a/app/Models/Company/ProjectMemberActivity.php
+++ b/app/Models/Company/ProjectMemberActivity.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Models\Company;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class ProjectMemberActivity extends Model
+{
+    use HasFactory;
+
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'project_member_activities';
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'project_id',
+        'employee_id',
+    ];
+
+    /**
+     * Get the project record associated with the activity.
+     *
+     * @return BelongsTo
+     */
+    public function project()
+    {
+        return $this->belongsTo(Project::class);
+    }
+
+    /**
+     * Get the employee record associated with the activity.
+     *
+     * @return BelongsTo
+     */
+    public function employee()
+    {
+        return $this->belongsTo(Employee::class);
+    }
+}

--- a/app/Services/Company/Project/AddFileToProject.php
+++ b/app/Services/Company/Project/AddFileToProject.php
@@ -7,6 +7,7 @@ use App\Models\Company\File;
 use App\Jobs\LogAccountAudit;
 use App\Services\BaseService;
 use App\Models\Company\Project;
+use App\Models\Company\ProjectMemberActivity;
 
 class AddFileToProject extends BaseService
 {
@@ -40,6 +41,7 @@ class AddFileToProject extends BaseService
         $this->data = $data;
         $this->validate();
         $this->assign();
+        $this->logActivity();
         $this->log();
 
         return $this->file;
@@ -66,6 +68,14 @@ class AddFileToProject extends BaseService
         /* @phpstan-ignore-next-line */
         $this->project->files()->syncWithoutDetaching([
             $this->data['file_id'],
+        ]);
+    }
+
+    private function logActivity(): void
+    {
+        ProjectMemberActivity::create([
+            'project_id' => $this->project->id,
+            'employee_id' => $this->author->id,
         ]);
     }
 

--- a/app/Services/Company/Project/AssignProjectTaskToEmployee.php
+++ b/app/Services/Company/Project/AssignProjectTaskToEmployee.php
@@ -8,9 +8,10 @@ use App\Services\BaseService;
 use App\Models\Company\Project;
 use App\Models\Company\Employee;
 use App\Models\Company\ProjectTask;
+use App\Models\Company\ProjectMemberActivity;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 
-class AssignProjecTaskToEmployee extends BaseService
+class AssignProjectTaskToEmployee extends BaseService
 {
     protected array $data;
 
@@ -47,6 +48,7 @@ class AssignProjecTaskToEmployee extends BaseService
         $this->data = $data;
         $this->validate();
         $this->assign();
+        $this->logActivity();
         $this->log();
 
         return $this->projectTask;
@@ -79,6 +81,14 @@ class AssignProjecTaskToEmployee extends BaseService
     {
         $this->projectTask->assignee_id = $this->assignee->id;
         $this->projectTask->save();
+    }
+
+    private function logActivity(): void
+    {
+        ProjectMemberActivity::create([
+            'project_id' => $this->project->id,
+            'employee_id' => $this->author->id,
+        ]);
     }
 
     private function log(): void

--- a/app/Services/Company/Project/AssignProjectTaskToTaskList.php
+++ b/app/Services/Company/Project/AssignProjectTaskToTaskList.php
@@ -9,7 +9,7 @@ use App\Models\Company\Project;
 use App\Models\Company\ProjectTask;
 use App\Models\Company\ProjectTaskList;
 
-class AssignProjecTaskToTaskList extends BaseService
+class AssignProjectTaskToTaskList extends BaseService
 {
     protected array $data;
 

--- a/app/Services/Company/Project/ClearProjectLead.php
+++ b/app/Services/Company/Project/ClearProjectLead.php
@@ -8,6 +8,7 @@ use App\Services\BaseService;
 use App\Jobs\LogEmployeeAudit;
 use App\Models\Company\Project;
 use App\Models\Company\Employee;
+use App\Models\Company\ProjectMemberActivity;
 
 class ClearProjectLead extends BaseService
 {
@@ -42,6 +43,7 @@ class ClearProjectLead extends BaseService
         $this->data = $data;
         $this->validate();
         $this->updateLead();
+        $this->logActivity();
         $this->log();
 
         return $this->project;
@@ -66,6 +68,14 @@ class ClearProjectLead extends BaseService
     {
         $this->project->project_lead_id = null;
         $this->project->save();
+    }
+
+    private function logActivity(): void
+    {
+        ProjectMemberActivity::create([
+            'project_id' => $this->project->id,
+            'employee_id' => $this->author->id,
+        ]);
     }
 
     private function log(): void

--- a/app/Services/Company/Project/CloseProject.php
+++ b/app/Services/Company/Project/CloseProject.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use App\Jobs\LogAccountAudit;
 use App\Services\BaseService;
 use App\Models\Company\Project;
+use App\Models\Company\ProjectMemberActivity;
 
 class CloseProject extends BaseService
 {
@@ -38,6 +39,7 @@ class CloseProject extends BaseService
         $this->data = $data;
         $this->validate();
         $this->stopProject();
+        $this->logActivity();
         $this->log();
 
         return $this->project;
@@ -61,6 +63,14 @@ class CloseProject extends BaseService
         $this->project->status = Project::CLOSED;
         $this->project->actually_finished_at = Carbon::now();
         $this->project->save();
+    }
+
+    private function logActivity(): void
+    {
+        ProjectMemberActivity::create([
+            'project_id' => $this->project->id,
+            'employee_id' => $this->author->id,
+        ]);
     }
 
     private function log(): void

--- a/app/Services/Company/Project/CreateProject.php
+++ b/app/Services/Company/Project/CreateProject.php
@@ -7,6 +7,7 @@ use App\Jobs\LogAccountAudit;
 use App\Services\BaseService;
 use App\Models\Company\Project;
 use App\Models\Company\Employee;
+use App\Models\Company\ProjectMemberActivity;
 use App\Exceptions\ProjectCodeAlreadyExistException;
 
 class CreateProject extends BaseService
@@ -44,6 +45,7 @@ class CreateProject extends BaseService
         $this->data = $data;
         $this->validate();
         $this->createProject();
+        $this->logActivity();
         $this->log();
 
         return $this->project;
@@ -95,6 +97,14 @@ class CreateProject extends BaseService
                 ],
             ]);
         }
+    }
+
+    private function logActivity(): void
+    {
+        ProjectMemberActivity::create([
+            'project_id' => $this->project->id,
+            'employee_id' => $this->author->id,
+        ]);
     }
 
     private function log(): void

--- a/app/Services/Company/Project/CreateProjectDecision.php
+++ b/app/Services/Company/Project/CreateProjectDecision.php
@@ -8,6 +8,7 @@ use App\Services\BaseService;
 use App\Models\Company\Project;
 use App\Models\Company\Employee;
 use App\Models\Company\ProjectDecision;
+use App\Models\Company\ProjectMemberActivity;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 class CreateProjectDecision extends BaseService
@@ -47,6 +48,7 @@ class CreateProjectDecision extends BaseService
         $this->validate();
         $this->createDecision();
         $this->attachEmployees();
+        $this->logActivity();
         $this->log();
 
         return $this->projectDecision;
@@ -95,6 +97,14 @@ class CreateProjectDecision extends BaseService
                 $employee->id,
             ]);
         }
+    }
+
+    private function logActivity(): void
+    {
+        ProjectMemberActivity::create([
+            'project_id' => $this->project->id,
+            'employee_id' => $this->author->id,
+        ]);
     }
 
     private function log(): void

--- a/app/Services/Company/Project/CreateProjectLink.php
+++ b/app/Services/Company/Project/CreateProjectLink.php
@@ -8,6 +8,7 @@ use App\Services\BaseService;
 use App\Models\Company\Project;
 use Illuminate\Validation\Rule;
 use App\Models\Company\ProjectLink;
+use App\Models\Company\ProjectMemberActivity;
 
 class CreateProjectLink extends BaseService
 {
@@ -52,6 +53,7 @@ class CreateProjectLink extends BaseService
         $this->data = $data;
         $this->validate();
         $this->createLink();
+        $this->logActivity();
         $this->log();
 
         return $this->projectLink;
@@ -77,6 +79,14 @@ class CreateProjectLink extends BaseService
             'label' => $this->valueOrNull($this->data, 'label'),
             'type' => $this->data['type'],
             'url' => $this->data['url'],
+        ]);
+    }
+
+    private function logActivity(): void
+    {
+        ProjectMemberActivity::create([
+            'project_id' => $this->project->id,
+            'employee_id' => $this->author->id,
         ]);
     }
 

--- a/app/Services/Company/Project/CreateProjectMessage.php
+++ b/app/Services/Company/Project/CreateProjectMessage.php
@@ -7,6 +7,7 @@ use App\Jobs\LogAccountAudit;
 use App\Services\BaseService;
 use App\Models\Company\Project;
 use App\Models\Company\ProjectMessage;
+use App\Models\Company\ProjectMemberActivity;
 
 class CreateProjectMessage extends BaseService
 {
@@ -44,6 +45,7 @@ class CreateProjectMessage extends BaseService
         $this->validate();
         $this->createMessage();
         $this->markAsReadForThisUser();
+        $this->logActivity();
         $this->log();
 
         return $this->projectMessage;
@@ -79,6 +81,14 @@ class CreateProjectMessage extends BaseService
             'author_id' => $this->data['author_id'],
             'project_id' => $this->data['project_id'],
             'project_message_id' => $this->projectMessage->id,
+        ]);
+    }
+
+    private function logActivity(): void
+    {
+        ProjectMemberActivity::create([
+            'project_id' => $this->project->id,
+            'employee_id' => $this->author->id,
         ]);
     }
 

--- a/app/Services/Company/Project/CreateProjectStatus.php
+++ b/app/Services/Company/Project/CreateProjectStatus.php
@@ -7,6 +7,7 @@ use App\Jobs\LogAccountAudit;
 use App\Services\BaseService;
 use App\Models\Company\Project;
 use App\Models\Company\ProjectStatus;
+use App\Models\Company\ProjectMemberActivity;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 class CreateProjectStatus extends BaseService
@@ -45,6 +46,7 @@ class CreateProjectStatus extends BaseService
         $this->data = $data;
         $this->validate();
         $this->createStatus();
+        $this->logActivity();
         $this->log();
 
         return $this->projectStatus;
@@ -75,6 +77,14 @@ class CreateProjectStatus extends BaseService
             'status' => $this->data['status'],
             'title' => $this->data['title'],
             'description' => $this->data['description'],
+        ]);
+    }
+
+    private function logActivity(): void
+    {
+        ProjectMemberActivity::create([
+            'project_id' => $this->project->id,
+            'employee_id' => $this->author->id,
         ]);
     }
 

--- a/app/Services/Company/Project/CreateProjectTask.php
+++ b/app/Services/Company/Project/CreateProjectTask.php
@@ -8,6 +8,7 @@ use App\Services\BaseService;
 use App\Models\Company\Project;
 use App\Models\Company\ProjectTask;
 use App\Models\Company\ProjectTaskList;
+use App\Models\Company\ProjectMemberActivity;
 
 class CreateProjectTask extends BaseService
 {
@@ -47,6 +48,7 @@ class CreateProjectTask extends BaseService
         $this->data = $data;
         $this->validate();
         $this->createTask();
+        $this->logActivity();
         $this->log();
 
         return $this->projectTask;
@@ -79,6 +81,14 @@ class CreateProjectTask extends BaseService
             'assignee_id' => $this->valueOrNull($this->data, 'assignee_id'),
             'title' => $this->data['title'],
             'description' => $this->data['description'],
+        ]);
+    }
+
+    private function logActivity(): void
+    {
+        ProjectMemberActivity::create([
+            'project_id' => $this->project->id,
+            'employee_id' => $this->author->id,
         ]);
     }
 

--- a/app/Services/Company/Project/CreateProjectTaskList.php
+++ b/app/Services/Company/Project/CreateProjectTaskList.php
@@ -7,6 +7,7 @@ use App\Jobs\LogAccountAudit;
 use App\Services\BaseService;
 use App\Models\Company\Project;
 use App\Models\Company\ProjectTaskList;
+use App\Models\Company\ProjectMemberActivity;
 
 class CreateProjectTaskList extends BaseService
 {
@@ -43,6 +44,7 @@ class CreateProjectTaskList extends BaseService
         $this->data = $data;
         $this->validate();
         $this->createTaskList();
+        $this->logActivity();
         $this->log();
 
         return $this->projectTaskList;
@@ -69,6 +71,14 @@ class CreateProjectTaskList extends BaseService
             'assignee_id' => $this->valueOrNull($this->data, 'assignee_id'),
             'title' => $this->data['title'],
             'description' => $this->valueOrNull($this->data, 'description'),
+        ]);
+    }
+
+    private function logActivity(): void
+    {
+        ProjectMemberActivity::create([
+            'project_id' => $this->project->id,
+            'employee_id' => $this->author->id,
         ]);
     }
 

--- a/app/Services/Company/Project/DestroyProjectDecision.php
+++ b/app/Services/Company/Project/DestroyProjectDecision.php
@@ -7,6 +7,7 @@ use App\Jobs\LogAccountAudit;
 use App\Services\BaseService;
 use App\Models\Company\Project;
 use App\Models\Company\ProjectDecision;
+use App\Models\Company\ProjectMemberActivity;
 
 class DestroyProjectDecision extends BaseService
 {
@@ -41,6 +42,7 @@ class DestroyProjectDecision extends BaseService
         $this->data = $data;
         $this->validate();
         $this->destroyDecision();
+        $this->logActivity();
         $this->log();
     }
 
@@ -63,6 +65,14 @@ class DestroyProjectDecision extends BaseService
     private function destroyDecision(): void
     {
         $this->projectDecision->delete();
+    }
+
+    private function logActivity(): void
+    {
+        ProjectMemberActivity::create([
+            'project_id' => $this->project->id,
+            'employee_id' => $this->author->id,
+        ]);
     }
 
     private function log(): void

--- a/app/Services/Company/Project/DestroyProjectFile.php
+++ b/app/Services/Company/Project/DestroyProjectFile.php
@@ -7,6 +7,7 @@ use App\Models\Company\File;
 use App\Jobs\LogAccountAudit;
 use App\Services\BaseService;
 use App\Models\Company\Project;
+use App\Models\Company\ProjectMemberActivity;
 
 class DestroyProjectFile extends BaseService
 {
@@ -39,6 +40,7 @@ class DestroyProjectFile extends BaseService
         $this->data = $data;
         $this->validate();
         $this->destroyFile();
+        $this->logActivity();
         $this->log();
     }
 
@@ -62,6 +64,14 @@ class DestroyProjectFile extends BaseService
         /* @phpstan-ignore-next-line */
         $this->project->files()->detach($this->data['file_id']);
         $this->file->delete();
+    }
+
+    private function logActivity(): void
+    {
+        ProjectMemberActivity::create([
+            'project_id' => $this->project->id,
+            'employee_id' => $this->author->id,
+        ]);
     }
 
     private function log(): void

--- a/app/Services/Company/Project/DestroyProjectLink.php
+++ b/app/Services/Company/Project/DestroyProjectLink.php
@@ -7,6 +7,7 @@ use App\Jobs\LogAccountAudit;
 use App\Services\BaseService;
 use App\Models\Company\Project;
 use App\Models\Company\ProjectLink;
+use App\Models\Company\ProjectMemberActivity;
 
 class DestroyProjectLink extends BaseService
 {
@@ -41,6 +42,7 @@ class DestroyProjectLink extends BaseService
         $this->data = $data;
         $this->validate();
         $this->deleteLink();
+        $this->logActivity();
         $this->log();
     }
 
@@ -63,6 +65,14 @@ class DestroyProjectLink extends BaseService
     private function deleteLink(): void
     {
         $this->projectLink->delete();
+    }
+
+    private function logActivity(): void
+    {
+        ProjectMemberActivity::create([
+            'project_id' => $this->project->id,
+            'employee_id' => $this->author->id,
+        ]);
     }
 
     private function log(): void

--- a/app/Services/Company/Project/DestroyProjectMessage.php
+++ b/app/Services/Company/Project/DestroyProjectMessage.php
@@ -7,6 +7,7 @@ use App\Jobs\LogAccountAudit;
 use App\Services\BaseService;
 use App\Models\Company\Project;
 use App\Models\Company\ProjectMessage;
+use App\Models\Company\ProjectMemberActivity;
 
 class DestroyProjectMessage extends BaseService
 {
@@ -41,6 +42,7 @@ class DestroyProjectMessage extends BaseService
         $this->data = $data;
         $this->validate();
         $this->destroyMessage();
+        $this->logActivity();
         $this->log();
     }
 
@@ -63,6 +65,14 @@ class DestroyProjectMessage extends BaseService
     private function destroyMessage(): void
     {
         $this->projectMessage->delete();
+    }
+
+    private function logActivity(): void
+    {
+        ProjectMemberActivity::create([
+            'project_id' => $this->project->id,
+            'employee_id' => $this->author->id,
+        ]);
     }
 
     private function log(): void

--- a/app/Services/Company/Project/DestroyProjectTask.php
+++ b/app/Services/Company/Project/DestroyProjectTask.php
@@ -7,6 +7,7 @@ use App\Jobs\LogAccountAudit;
 use App\Services\BaseService;
 use App\Models\Company\Project;
 use App\Models\Company\ProjectTask;
+use App\Models\Company\ProjectMemberActivity;
 
 class DestroyProjectTask extends BaseService
 {
@@ -41,6 +42,7 @@ class DestroyProjectTask extends BaseService
         $this->data = $data;
         $this->validate();
         $this->destroyTask();
+        $this->logActivity();
         $this->log();
     }
 
@@ -63,6 +65,14 @@ class DestroyProjectTask extends BaseService
     private function destroyTask(): void
     {
         $this->projectTask->delete();
+    }
+
+    private function logActivity(): void
+    {
+        ProjectMemberActivity::create([
+            'project_id' => $this->project->id,
+            'employee_id' => $this->author->id,
+        ]);
     }
 
     private function log(): void

--- a/app/Services/Company/Project/DestroyProjectTaskList.php
+++ b/app/Services/Company/Project/DestroyProjectTaskList.php
@@ -7,6 +7,7 @@ use App\Jobs\LogAccountAudit;
 use App\Services\BaseService;
 use App\Models\Company\Project;
 use App\Models\Company\ProjectTaskList;
+use App\Models\Company\ProjectMemberActivity;
 
 class DestroyProjectTaskList extends BaseService
 {
@@ -41,6 +42,7 @@ class DestroyProjectTaskList extends BaseService
         $this->data = $data;
         $this->validate();
         $this->destroyTaskList();
+        $this->logActivity();
         $this->log();
     }
 
@@ -63,6 +65,14 @@ class DestroyProjectTaskList extends BaseService
     private function destroyTaskList(): void
     {
         $this->projectTaskList->delete();
+    }
+
+    private function logActivity(): void
+    {
+        ProjectMemberActivity::create([
+            'project_id' => $this->project->id,
+            'employee_id' => $this->author->id,
+        ]);
     }
 
     private function log(): void

--- a/app/Services/Company/Project/MarkProjectMessageasRead.php
+++ b/app/Services/Company/Project/MarkProjectMessageasRead.php
@@ -7,6 +7,7 @@ use App\Services\BaseService;
 use App\Models\Company\Project;
 use Illuminate\Support\Facades\DB;
 use App\Models\Company\ProjectMessage;
+use App\Models\Company\ProjectMemberActivity;
 
 class MarkProjectMessageasRead extends BaseService
 {
@@ -41,6 +42,7 @@ class MarkProjectMessageasRead extends BaseService
         $this->data = $data;
         $this->validate();
         $this->read();
+        $this->logActivity();
     }
 
     private function validate(): void
@@ -74,6 +76,14 @@ class MarkProjectMessageasRead extends BaseService
             'project_message_id' => $this->projectMessage->id,
             'employee_id' => $this->author->id,
             'created_at' => Carbon::now(),
+        ]);
+    }
+
+    private function logActivity(): void
+    {
+        ProjectMemberActivity::create([
+            'project_id' => $this->project->id,
+            'employee_id' => $this->author->id,
         ]);
     }
 }

--- a/app/Services/Company/Project/PauseProject.php
+++ b/app/Services/Company/Project/PauseProject.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use App\Jobs\LogAccountAudit;
 use App\Services\BaseService;
 use App\Models\Company\Project;
+use App\Models\Company\ProjectMemberActivity;
 
 class PauseProject extends BaseService
 {
@@ -38,6 +39,7 @@ class PauseProject extends BaseService
         $this->data = $data;
         $this->validate();
         $this->pauseProject();
+        $this->logActivity();
         $this->log();
 
         return $this->project;
@@ -60,6 +62,14 @@ class PauseProject extends BaseService
     {
         $this->project->status = Project::PAUSED;
         $this->project->save();
+    }
+
+    private function logActivity(): void
+    {
+        ProjectMemberActivity::create([
+            'project_id' => $this->project->id,
+            'employee_id' => $this->author->id,
+        ]);
     }
 
     private function log(): void

--- a/app/Services/Company/Project/RemoveEmployeeFromProject.php
+++ b/app/Services/Company/Project/RemoveEmployeeFromProject.php
@@ -8,6 +8,7 @@ use App\Services\BaseService;
 use App\Jobs\LogEmployeeAudit;
 use App\Models\Company\Project;
 use App\Models\Company\Employee;
+use App\Models\Company\ProjectMemberActivity;
 
 class RemoveEmployeeFromProject extends BaseService
 {
@@ -42,6 +43,7 @@ class RemoveEmployeeFromProject extends BaseService
         $this->data = $data;
         $this->validate();
         $this->detachEmployee();
+        $this->logActivity();
         $this->log();
     }
 
@@ -64,6 +66,14 @@ class RemoveEmployeeFromProject extends BaseService
     private function detachEmployee(): void
     {
         $this->project->employees()->detach($this->data['employee_id']);
+    }
+
+    private function logActivity(): void
+    {
+        ProjectMemberActivity::create([
+            'project_id' => $this->project->id,
+            'employee_id' => $this->author->id,
+        ]);
     }
 
     private function log(): void

--- a/app/Services/Company/Project/StartProject.php
+++ b/app/Services/Company/Project/StartProject.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use App\Jobs\LogAccountAudit;
 use App\Services\BaseService;
 use App\Models\Company\Project;
+use App\Models\Company\ProjectMemberActivity;
 
 class StartProject extends BaseService
 {
@@ -38,6 +39,7 @@ class StartProject extends BaseService
         $this->data = $data;
         $this->validate();
         $this->startProject();
+        $this->logActivity();
         $this->log();
 
         return $this->project;
@@ -61,6 +63,14 @@ class StartProject extends BaseService
         $this->project->status = Project::STARTED;
         $this->project->started_at = Carbon::now();
         $this->project->save();
+    }
+
+    private function logActivity(): void
+    {
+        ProjectMemberActivity::create([
+            'project_id' => $this->project->id,
+            'employee_id' => $this->author->id,
+        ]);
     }
 
     private function log(): void

--- a/app/Services/Company/Project/ToggleProjectTask.php
+++ b/app/Services/Company/Project/ToggleProjectTask.php
@@ -7,6 +7,7 @@ use App\Jobs\LogAccountAudit;
 use App\Services\BaseService;
 use App\Models\Company\Project;
 use App\Models\Company\ProjectTask;
+use App\Models\Company\ProjectMemberActivity;
 
 class ToggleProjectTask extends BaseService
 {
@@ -42,6 +43,7 @@ class ToggleProjectTask extends BaseService
         $this->data = $data;
         $this->validate();
         $this->toggle();
+        $this->logActivity();
         $this->log();
 
         return $this->projectTask;
@@ -73,6 +75,14 @@ class ToggleProjectTask extends BaseService
 
         $this->projectTask->completed = ! $this->projectTask->completed;
         $this->projectTask->save();
+    }
+
+    private function logActivity(): void
+    {
+        ProjectMemberActivity::create([
+            'project_id' => $this->project->id,
+            'employee_id' => $this->author->id,
+        ]);
     }
 
     private function log(): void

--- a/app/Services/Company/Project/UpdateProjectDescription.php
+++ b/app/Services/Company/Project/UpdateProjectDescription.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use App\Jobs\LogAccountAudit;
 use App\Services\BaseService;
 use App\Models\Company\Project;
+use App\Models\Company\ProjectMemberActivity;
 
 class UpdateProjectDescription extends BaseService
 {
@@ -39,6 +40,7 @@ class UpdateProjectDescription extends BaseService
         $this->data = $data;
         $this->validate();
         $this->update();
+        $this->logActivity();
         $this->log();
 
         return $this->project;
@@ -61,6 +63,14 @@ class UpdateProjectDescription extends BaseService
     {
         $this->project->description = $this->valueOrNull($this->data, 'description');
         $this->project->save();
+    }
+
+    private function logActivity(): void
+    {
+        ProjectMemberActivity::create([
+            'project_id' => $this->project->id,
+            'employee_id' => $this->author->id,
+        ]);
     }
 
     private function log(): void

--- a/app/Services/Company/Project/UpdateProjectInformation.php
+++ b/app/Services/Company/Project/UpdateProjectInformation.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use App\Jobs\LogAccountAudit;
 use App\Services\BaseService;
 use App\Models\Company\Project;
+use App\Models\Company\ProjectMemberActivity;
 use App\Exceptions\ProjectCodeAlreadyExistException;
 
 class UpdateProjectInformation extends BaseService
@@ -42,6 +43,7 @@ class UpdateProjectInformation extends BaseService
         $this->data = $data;
         $this->validate();
         $this->update();
+        $this->logActivity();
         $this->log();
 
         return $this->project;
@@ -78,6 +80,14 @@ class UpdateProjectInformation extends BaseService
         $this->project->code = $this->data['code'];
         $this->project->summary = $this->data['summary'];
         $this->project->save();
+    }
+
+    private function logActivity(): void
+    {
+        ProjectMemberActivity::create([
+            'project_id' => $this->project->id,
+            'employee_id' => $this->author->id,
+        ]);
     }
 
     private function log(): void

--- a/app/Services/Company/Project/UpdateProjectLead.php
+++ b/app/Services/Company/Project/UpdateProjectLead.php
@@ -8,6 +8,7 @@ use App\Services\BaseService;
 use App\Jobs\LogEmployeeAudit;
 use App\Models\Company\Project;
 use App\Models\Company\Employee;
+use App\Models\Company\ProjectMemberActivity;
 
 class UpdateProjectLead extends BaseService
 {
@@ -43,6 +44,7 @@ class UpdateProjectLead extends BaseService
         $this->data = $data;
         $this->validate();
         $this->updateLead();
+        $this->logActivity();
         $this->log();
 
         return $this->employee;
@@ -78,6 +80,14 @@ class UpdateProjectLead extends BaseService
                 ],
             ]);
         }
+    }
+
+    private function logActivity(): void
+    {
+        ProjectMemberActivity::create([
+            'project_id' => $this->project->id,
+            'employee_id' => $this->author->id,
+        ]);
     }
 
     private function log(): void

--- a/app/Services/Company/Project/UpdateProjectMessage.php
+++ b/app/Services/Company/Project/UpdateProjectMessage.php
@@ -7,6 +7,7 @@ use App\Jobs\LogAccountAudit;
 use App\Services\BaseService;
 use App\Models\Company\Project;
 use App\Models\Company\ProjectMessage;
+use App\Models\Company\ProjectMemberActivity;
 
 class UpdateProjectMessage extends BaseService
 {
@@ -44,6 +45,7 @@ class UpdateProjectMessage extends BaseService
         $this->data = $data;
         $this->validate();
         $this->update();
+        $this->logActivity();
         $this->log();
 
         return $this->projectMessage;
@@ -70,6 +72,14 @@ class UpdateProjectMessage extends BaseService
         $this->projectMessage->title = $this->data['title'];
         $this->projectMessage->content = $this->data['content'];
         $this->projectMessage->save();
+    }
+
+    private function logActivity(): void
+    {
+        ProjectMemberActivity::create([
+            'project_id' => $this->project->id,
+            'employee_id' => $this->author->id,
+        ]);
     }
 
     private function log(): void

--- a/app/Services/Company/Project/UpdateProjectTask.php
+++ b/app/Services/Company/Project/UpdateProjectTask.php
@@ -7,6 +7,7 @@ use App\Jobs\LogAccountAudit;
 use App\Services\BaseService;
 use App\Models\Company\Project;
 use App\Models\Company\ProjectTask;
+use App\Models\Company\ProjectMemberActivity;
 
 class UpdateProjectTask extends BaseService
 {
@@ -44,6 +45,7 @@ class UpdateProjectTask extends BaseService
         $this->data = $data;
         $this->validate();
         $this->update();
+        $this->logActivity();
         $this->log();
 
         return $this->projectTask;
@@ -70,6 +72,14 @@ class UpdateProjectTask extends BaseService
         $this->projectTask->title = $this->data['title'];
         $this->projectTask->description = $this->valueOrNull($this->data, 'description');
         $this->projectTask->save();
+    }
+
+    private function logActivity(): void
+    {
+        ProjectMemberActivity::create([
+            'project_id' => $this->project->id,
+            'employee_id' => $this->author->id,
+        ]);
     }
 
     private function log(): void

--- a/app/Services/Company/Project/UpdateProjectTaskList.php
+++ b/app/Services/Company/Project/UpdateProjectTaskList.php
@@ -7,6 +7,7 @@ use App\Jobs\LogAccountAudit;
 use App\Services\BaseService;
 use App\Models\Company\Project;
 use App\Models\Company\ProjectTaskList;
+use App\Models\Company\ProjectMemberActivity;
 
 class UpdateProjectTaskList extends BaseService
 {
@@ -44,6 +45,7 @@ class UpdateProjectTaskList extends BaseService
         $this->data = $data;
         $this->validate();
         $this->update();
+        $this->logActivity();
         $this->log();
 
         return $this->projectTaskList;
@@ -70,6 +72,14 @@ class UpdateProjectTaskList extends BaseService
         $this->projectTaskList->title = $this->data['title'];
         $this->projectTaskList->description = $this->valueOrNull($this->data, 'description');
         $this->projectTaskList->save();
+    }
+
+    private function logActivity(): void
+    {
+        ProjectMemberActivity::create([
+            'project_id' => $this->project->id,
+            'employee_id' => $this->author->id,
+        ]);
     }
 
     private function log(): void

--- a/database/factories/Company/ProjectMemberActivityFactory.php
+++ b/database/factories/Company/ProjectMemberActivityFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Factories\Company;
+
+use App\Models\Company\Project;
+use App\Models\Company\Employee;
+use App\Models\Company\ProjectMemberActivity;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ProjectMemberActivityFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = ProjectMemberActivity::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'employee_id' => Employee::factory(),
+            'project_id' => Project::factory(),
+        ];
+    }
+}

--- a/database/migrations/2021_04_20_180102_create_sessions_table.php
+++ b/database/migrations/2021_04_20_180102_create_sessions_table.php
@@ -11,6 +11,9 @@ class CreateSessionsTable extends Migration
      */
     public function up()
     {
+        // necessary for SQLlite
+        Schema::enableForeignKeyConstraints();
+
         Schema::create('sessions', function (Blueprint $table) {
             $table->string('id')->primary();
             $table->foreignId('user_id')->nullable()->index();
@@ -19,13 +22,5 @@ class CreateSessionsTable extends Migration
             $table->text('payload');
             $table->integer('last_activity')->index();
         });
-    }
-
-    /**
-     * Reverse the migrations.
-     */
-    public function down()
-    {
-        Schema::dropIfExists('sessions');
     }
 }

--- a/database/migrations/2021_04_22_005032_create_project_member_activity_table.php
+++ b/database/migrations/2021_04_22_005032_create_project_member_activity_table.php
@@ -4,22 +4,20 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class CreateFileProjectTable extends Migration
+class CreateProjectMemberActivityTable extends Migration
 {
     /**
      * Run the migrations.
      */
     public function up()
     {
-        // necessary for SQLlite
-        Schema::enableForeignKeyConstraints();
-
-        Schema::create('file_project', function (Blueprint $table) {
-            $table->unsignedBigInteger('file_id');
+        Schema::create('project_member_activities', function (Blueprint $table) {
+            $table->id();
             $table->unsignedBigInteger('project_id');
+            $table->unsignedBigInteger('employee_id');
             $table->timestamps();
-            $table->foreign('file_id')->references('id')->on('files')->onDelete('cascade');
             $table->foreign('project_id')->references('id')->on('projects')->onDelete('cascade');
+            $table->foreign('employee_id')->references('id')->on('employees')->onDelete('cascade');
         });
     }
 }

--- a/tests/Unit/Models/Company/ProjectMemberActivityTest.php
+++ b/tests/Unit/Models/Company/ProjectMemberActivityTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Unit\Models\Company;
+
+use Tests\TestCase;
+use App\Models\Company\ProjectMemberActivity;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+class ProjectMemberActivityTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    /** @test */
+    public function it_belongs_to_a_project(): void
+    {
+        $activity = ProjectMemberActivity::factory()->create();
+        $this->assertTrue($activity->project()->exists());
+    }
+
+    /** @test */
+    public function it_has_one_employee(): void
+    {
+        $activity = ProjectMemberActivity::factory()->create();
+        $this->assertTrue($activity->employee()->exists());
+    }
+}

--- a/tests/Unit/Services/Company/Project/AddFileToProjectTest.php
+++ b/tests/Unit/Services/Company/Project/AddFileToProjectTest.php
@@ -111,6 +111,11 @@ class AddFileToProjectTest extends TestCase
             'file_id' => $file->id,
         ]);
 
+        $this->assertDatabaseHas('project_member_activities', [
+            'project_id' => $project->id,
+            'employee_id' => $michael->id,
+        ]);
+
         $this->assertInstanceOf(
             File::class,
             $file

--- a/tests/Unit/Services/Company/Project/AssignProjectTaskToEmployeeTest.php
+++ b/tests/Unit/Services/Company/Project/AssignProjectTaskToEmployeeTest.php
@@ -11,9 +11,9 @@ use Illuminate\Support\Facades\Queue;
 use Illuminate\Validation\ValidationException;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
-use App\Services\Company\Project\AssignProjecTaskToEmployee;
+use App\Services\Company\Project\AssignProjectTaskToEmployee;
 
-class AssignProjecTaskToEmployeeTest extends TestCase
+class AssignProjectTaskToEmployeeTest extends TestCase
 {
     use DatabaseTransactions;
 
@@ -70,7 +70,7 @@ class AssignProjecTaskToEmployeeTest extends TestCase
         ];
 
         $this->expectException(ValidationException::class);
-        (new AssignProjecTaskToEmployee)->execute($request);
+        (new AssignProjectTaskToEmployee)->execute($request);
     }
 
     /** @test */
@@ -131,7 +131,7 @@ class AssignProjecTaskToEmployeeTest extends TestCase
             'assignee_id' => $assignee->id,
         ];
 
-        $task = (new AssignProjecTaskToEmployee)->execute($request);
+        $task = (new AssignProjectTaskToEmployee)->execute($request);
 
         $this->assertInstanceOf(
             ProjectTask::class,
@@ -141,6 +141,11 @@ class AssignProjecTaskToEmployeeTest extends TestCase
         $this->assertDatabaseHas('project_tasks', [
             'id' => $task->id,
             'assignee_id' => $assignee->id,
+        ]);
+
+        $this->assertDatabaseHas('project_member_activities', [
+            'project_id' => $project->id,
+            'employee_id' => $michael->id,
         ]);
 
         Queue::assertPushed(LogAccountAudit::class, function ($job) use ($michael, $project, $task, $assignee) {

--- a/tests/Unit/Services/Company/Project/AssignProjectTaskToTaskListTest.php
+++ b/tests/Unit/Services/Company/Project/AssignProjectTaskToTaskListTest.php
@@ -12,9 +12,9 @@ use App\Models\Company\ProjectTaskList;
 use Illuminate\Validation\ValidationException;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
-use App\Services\Company\Project\AssignProjecTaskToTaskList;
+use App\Services\Company\Project\AssignProjectTaskToTaskList;
 
-class AssignProjecTaskToTaskListTest extends TestCase
+class AssignProjectTaskToTaskListTest extends TestCase
 {
     use DatabaseTransactions;
 
@@ -74,7 +74,7 @@ class AssignProjecTaskToTaskListTest extends TestCase
         ];
 
         $this->expectException(ValidationException::class);
-        (new AssignProjecTaskToTaskList)->execute($request);
+        (new AssignProjectTaskToTaskList)->execute($request);
     }
 
     /** @test */
@@ -137,7 +137,7 @@ class AssignProjecTaskToTaskListTest extends TestCase
             'project_task_list_id' => $projectTaskList->id,
         ];
 
-        $task = (new AssignProjecTaskToTaskList)->execute($request);
+        $task = (new AssignProjectTaskToTaskList)->execute($request);
 
         $this->assertInstanceOf(
             ProjectTask::class,

--- a/tests/Unit/Services/Company/Project/ClearProjectLeadTest.php
+++ b/tests/Unit/Services/Company/Project/ClearProjectLeadTest.php
@@ -95,6 +95,11 @@ class ClearProjectLeadTest extends TestCase
             'project_lead_id' => null,
         ]);
 
+        $this->assertDatabaseHas('project_member_activities', [
+            'project_id' => $project->id,
+            'employee_id' => $michael->id,
+        ]);
+
         $this->assertInstanceOf(
             Project::class,
             $project

--- a/tests/Unit/Services/Company/Project/CloseProjectTest.php
+++ b/tests/Unit/Services/Company/Project/CloseProjectTest.php
@@ -89,6 +89,11 @@ class CloseProjectTest extends TestCase
             'actually_finished_at' => '2019-01-01 00:00:00',
         ]);
 
+        $this->assertDatabaseHas('project_member_activities', [
+            'project_id' => $project->id,
+            'employee_id' => $michael->id,
+        ]);
+
         Queue::assertPushed(LogAccountAudit::class, function ($job) use ($michael, $project) {
             return $job->auditLog['action'] === 'project_closed' &&
                 $job->auditLog['author_id'] === $michael->id &&

--- a/tests/Unit/Services/Company/Project/CreateProjectDecisionTest.php
+++ b/tests/Unit/Services/Company/Project/CreateProjectDecisionTest.php
@@ -113,6 +113,11 @@ class CreateProjectDecisionTest extends TestCase
             'employee_id' => $dwight->id,
         ]);
 
+        $this->assertDatabaseHas('project_member_activities', [
+            'project_id' => $project->id,
+            'employee_id' => $michael->id,
+        ]);
+
         $this->assertInstanceOf(
             ProjectDecision::class,
             $projectDecision

--- a/tests/Unit/Services/Company/Project/CreateProjectLinkTest.php
+++ b/tests/Unit/Services/Company/Project/CreateProjectLinkTest.php
@@ -93,6 +93,11 @@ class CreateProjectLinkTest extends TestCase
             'url' => 'https',
         ]);
 
+        $this->assertDatabaseHas('project_member_activities', [
+            'project_id' => $project->id,
+            'employee_id' => $michael->id,
+        ]);
+
         $this->assertInstanceOf(
             ProjectLink::class,
             $projectLink

--- a/tests/Unit/Services/Company/Project/CreateProjectMessageTest.php
+++ b/tests/Unit/Services/Company/Project/CreateProjectMessageTest.php
@@ -95,6 +95,11 @@ class CreateProjectMessageTest extends TestCase
             'employee_id' => $michael->id,
         ]);
 
+        $this->assertDatabaseHas('project_member_activities', [
+            'project_id' => $project->id,
+            'employee_id' => $michael->id,
+        ]);
+
         $this->assertInstanceOf(
             ProjectMessage::class,
             $projectMessage

--- a/tests/Unit/Services/Company/Project/CreateProjectStatusTest.php
+++ b/tests/Unit/Services/Company/Project/CreateProjectStatusTest.php
@@ -105,6 +105,11 @@ class CreateProjectStatusTest extends TestCase
             'description' => 'https',
         ]);
 
+        $this->assertDatabaseHas('project_member_activities', [
+            'project_id' => $project->id,
+            'employee_id' => $michael->id,
+        ]);
+
         $this->assertInstanceOf(
             ProjectStatus::class,
             $projectStatus

--- a/tests/Unit/Services/Company/Project/CreateProjectTaskTest.php
+++ b/tests/Unit/Services/Company/Project/CreateProjectTaskTest.php
@@ -119,6 +119,11 @@ class CreateProjectTaskTest extends TestCase
             'description' => $task->description,
         ]);
 
+        $this->assertDatabaseHas('project_member_activities', [
+            'project_id' => $project->id,
+            'employee_id' => $michael->id,
+        ]);
+
         $this->assertInstanceOf(
             ProjectTask::class,
             $task

--- a/tests/Unit/Services/Company/Project/CreateProjectTest.php
+++ b/tests/Unit/Services/Company/Project/CreateProjectTest.php
@@ -106,6 +106,11 @@ class CreateProjectTest extends TestCase
             'name' => 'Livraison API v3',
         ]);
 
+        $this->assertDatabaseHas('project_member_activities', [
+            'project_id' => $project->id,
+            'employee_id' => $michael->id,
+        ]);
+
         if ($lead) {
             $this->assertDatabaseHas('employee_project', [
                 'employee_id' => $lead->id,

--- a/tests/Unit/Services/Company/Project/DestroyProjectDecisionTest.php
+++ b/tests/Unit/Services/Company/Project/DestroyProjectDecisionTest.php
@@ -115,6 +115,11 @@ class DestroyProjectDecisionTest extends TestCase
             'id' => $decision->id,
         ]);
 
+        $this->assertDatabaseHas('project_member_activities', [
+            'project_id' => $project->id,
+            'employee_id' => $michael->id,
+        ]);
+
         Queue::assertPushed(LogAccountAudit::class, function ($job) use ($michael, $project, $decision) {
             return $job->auditLog['action'] === 'project_decision_destroyed' &&
                 $job->auditLog['author_id'] === $michael->id &&

--- a/tests/Unit/Services/Company/Project/DestroyProjectLinkTest.php
+++ b/tests/Unit/Services/Company/Project/DestroyProjectLinkTest.php
@@ -114,6 +114,11 @@ class DestroyProjectLinkTest extends TestCase
             'id' => $link->id,
         ]);
 
+        $this->assertDatabaseHas('project_member_activities', [
+            'project_id' => $project->id,
+            'employee_id' => $michael->id,
+        ]);
+
         Queue::assertPushed(LogAccountAudit::class, function ($job) use ($michael, $project, $link) {
             return $job->auditLog['action'] === 'project_link_destroyed' &&
                 $job->auditLog['author_id'] === $michael->id &&

--- a/tests/Unit/Services/Company/Project/DestroyProjectMessageTest.php
+++ b/tests/Unit/Services/Company/Project/DestroyProjectMessageTest.php
@@ -111,6 +111,11 @@ class DestroyProjectMessageTest extends TestCase
             'id' => $message->id,
         ]);
 
+        $this->assertDatabaseHas('project_member_activities', [
+            'project_id' => $project->id,
+            'employee_id' => $michael->id,
+        ]);
+
         Queue::assertPushed(LogAccountAudit::class, function ($job) use ($michael, $project, $message) {
             return $job->auditLog['action'] === 'project_message_destroyed' &&
                 $job->auditLog['author_id'] === $michael->id &&

--- a/tests/Unit/Services/Company/Project/DestroyProjectTaskListTest.php
+++ b/tests/Unit/Services/Company/Project/DestroyProjectTaskListTest.php
@@ -110,6 +110,11 @@ class DestroyProjectTaskListTest extends TestCase
             'id' => $taskList->id,
         ]);
 
+        $this->assertDatabaseHas('project_member_activities', [
+            'project_id' => $project->id,
+            'employee_id' => $michael->id,
+        ]);
+
         Queue::assertPushed(LogAccountAudit::class, function ($job) use ($michael, $project, $taskList) {
             return $job->auditLog['action'] === 'project_task_list_destroyed' &&
                 $job->auditLog['author_id'] === $michael->id &&

--- a/tests/Unit/Services/Company/Project/DestroyProjectTaskTest.php
+++ b/tests/Unit/Services/Company/Project/DestroyProjectTaskTest.php
@@ -111,6 +111,11 @@ class DestroyProjectTaskTest extends TestCase
             'id' => $task->id,
         ]);
 
+        $this->assertDatabaseHas('project_member_activities', [
+            'project_id' => $project->id,
+            'employee_id' => $michael->id,
+        ]);
+
         Queue::assertPushed(LogAccountAudit::class, function ($job) use ($michael, $project, $task) {
             return $job->auditLog['action'] === 'project_task_destroyed' &&
                 $job->auditLog['author_id'] === $michael->id &&

--- a/tests/Unit/Services/Company/Project/MarkProjectMessageasReadTest.php
+++ b/tests/Unit/Services/Company/Project/MarkProjectMessageasReadTest.php
@@ -110,5 +110,10 @@ class MarkProjectMessageasReadTest extends TestCase
             'project_message_id' => $message->id,
             'employee_id' => $michael->id,
         ]);
+
+        $this->assertDatabaseHas('project_member_activities', [
+            'project_id' => $project->id,
+            'employee_id' => $michael->id,
+        ]);
     }
 }

--- a/tests/Unit/Services/Company/Project/PauseProjectTest.php
+++ b/tests/Unit/Services/Company/Project/PauseProjectTest.php
@@ -86,6 +86,11 @@ class PauseProjectTest extends TestCase
             'status' => Project::PAUSED,
         ]);
 
+        $this->assertDatabaseHas('project_member_activities', [
+            'project_id' => $project->id,
+            'employee_id' => $michael->id,
+        ]);
+
         Queue::assertPushed(LogAccountAudit::class, function ($job) use ($michael, $project) {
             return $job->auditLog['action'] === 'project_paused' &&
                 $job->auditLog['author_id'] === $michael->id &&

--- a/tests/Unit/Services/Company/Project/RemoveEmployeeFromProjectTest.php
+++ b/tests/Unit/Services/Company/Project/RemoveEmployeeFromProjectTest.php
@@ -108,6 +108,11 @@ class RemoveEmployeeFromProjectTest extends TestCase
             'employee_id' => $dwight->id,
         ]);
 
+        $this->assertDatabaseHas('project_member_activities', [
+            'project_id' => $project->id,
+            'employee_id' => $michael->id,
+        ]);
+
         Queue::assertPushed(LogAccountAudit::class, function ($job) use ($michael, $project, $dwight) {
             return $job->auditLog['action'] === 'employee_removed_from_project' &&
                 $job->auditLog['author_id'] === $michael->id &&

--- a/tests/Unit/Services/Company/Project/StartProjectTest.php
+++ b/tests/Unit/Services/Company/Project/StartProjectTest.php
@@ -88,6 +88,11 @@ class StartProjectTest extends TestCase
             'status' => Project::STARTED,
         ]);
 
+        $this->assertDatabaseHas('project_member_activities', [
+            'project_id' => $project->id,
+            'employee_id' => $michael->id,
+        ]);
+
         $this->assertNotNull($project->started_at);
 
         Queue::assertPushed(LogAccountAudit::class, function ($job) use ($michael, $project) {

--- a/tests/Unit/Services/Company/Project/ToggleProjectTaskTest.php
+++ b/tests/Unit/Services/Company/Project/ToggleProjectTaskTest.php
@@ -116,6 +116,11 @@ class ToggleProjectTaskTest extends TestCase
             'completed' => true,
         ]);
 
+        $this->assertDatabaseHas('project_member_activities', [
+            'project_id' => $project->id,
+            'employee_id' => $michael->id,
+        ]);
+
         Queue::assertPushed(LogAccountAudit::class, function ($job) use ($michael, $project, $task) {
             return $job->auditLog['action'] === 'project_task_toggled' &&
                 $job->auditLog['author_id'] === $michael->id &&

--- a/tests/Unit/Services/Company/Project/UpdateProjectDescriptionTest.php
+++ b/tests/Unit/Services/Company/Project/UpdateProjectDescriptionTest.php
@@ -87,6 +87,11 @@ class UpdateProjectDescriptionTest extends TestCase
             'description' => 'Project description',
         ]);
 
+        $this->assertDatabaseHas('project_member_activities', [
+            'project_id' => $project->id,
+            'employee_id' => $michael->id,
+        ]);
+
         Queue::assertPushed(LogAccountAudit::class, function ($job) use ($michael, $project) {
             return $job->auditLog['action'] === 'project_description_updated' &&
                 $job->auditLog['author_id'] === $michael->id &&

--- a/tests/Unit/Services/Company/Project/UpdateProjectInformationTest.php
+++ b/tests/Unit/Services/Company/Project/UpdateProjectInformationTest.php
@@ -98,6 +98,11 @@ class UpdateProjectInformationTest extends TestCase
             'summary' => 'awesome project',
         ]);
 
+        $this->assertDatabaseHas('project_member_activities', [
+            'project_id' => $project->id,
+            'employee_id' => $michael->id,
+        ]);
+
         $this->assertInstanceOf(
             Project::class,
             $project

--- a/tests/Unit/Services/Company/Project/UpdateProjectLeadTest.php
+++ b/tests/Unit/Services/Company/Project/UpdateProjectLeadTest.php
@@ -108,6 +108,11 @@ class UpdateProjectLeadTest extends TestCase
             'employee_id' => $dwight->id,
         ]);
 
+        $this->assertDatabaseHas('project_member_activities', [
+            'project_id' => $project->id,
+            'employee_id' => $michael->id,
+        ]);
+
         $this->assertInstanceOf(
             Employee::class,
             $employee

--- a/tests/Unit/Services/Company/Project/UpdateProjectMessageTest.php
+++ b/tests/Unit/Services/Company/Project/UpdateProjectMessageTest.php
@@ -114,6 +114,11 @@ class UpdateProjectMessageTest extends TestCase
             'content' => 'Content',
         ]);
 
+        $this->assertDatabaseHas('project_member_activities', [
+            'project_id' => $project->id,
+            'employee_id' => $michael->id,
+        ]);
+
         Queue::assertPushed(LogAccountAudit::class, function ($job) use ($michael, $project, $message) {
             return $job->auditLog['action'] === 'project_message_updated' &&
                 $job->auditLog['author_id'] === $michael->id &&

--- a/tests/Unit/Services/Company/Project/UpdateProjectTaskListTest.php
+++ b/tests/Unit/Services/Company/Project/UpdateProjectTaskListTest.php
@@ -114,6 +114,11 @@ class UpdateProjectTaskListTest extends TestCase
             'description' => 'Content',
         ]);
 
+        $this->assertDatabaseHas('project_member_activities', [
+            'project_id' => $project->id,
+            'employee_id' => $michael->id,
+        ]);
+
         Queue::assertPushed(LogAccountAudit::class, function ($job) use ($michael, $project, $taskList) {
             return $job->auditLog['action'] === 'project_task_list_updated' &&
                 $job->auditLog['author_id'] === $michael->id &&

--- a/tests/Unit/Services/Company/Project/UpdateProjectTaskTest.php
+++ b/tests/Unit/Services/Company/Project/UpdateProjectTaskTest.php
@@ -114,6 +114,11 @@ class UpdateProjectTaskTest extends TestCase
             'description' => 'Content',
         ]);
 
+        $this->assertDatabaseHas('project_member_activities', [
+            'project_id' => $project->id,
+            'employee_id' => $michael->id,
+        ]);
+
         Queue::assertPushed(LogAccountAudit::class, function ($job) use ($michael, $project, $task) {
             return $job->auditLog['action'] === 'project_task_updated' &&
                 $job->auditLog['author_id'] === $michael->id &&


### PR DESCRIPTION
We need to record the activity of the members of a project.

This is necessary to display the employee's report at the end of each year (as addressed in #814), so we can know precisely which project the employee participated in during the given year.