### PR TITLE
fix: fix verification email being sent twice

### DIFF
--- a/app/Services/User/CreateAccount.php
+++ b/app/Services/User/CreateAccount.php
@@ -13,6 +13,8 @@ class CreateAccount extends BaseService implements CreatesNewUsers
 {
     use PasswordValidationRules;
 
+    private User $user;
+
     /**
      * Get the validation rules that apply to the service.
      *
@@ -57,30 +59,26 @@ class CreateAccount extends BaseService implements CreatesNewUsers
     {
         $this->validateRules($data);
 
-        $user = $this->createUser($data);
+        $this->createUser($data);
 
         if (! config('mail.verify') || User::count() == 1) {
             // if it's the first user, we can skip the email verification
-            $user->markEmailAsVerified();
-        } else {
-            $user->sendEmailVerificationNotification();
+            $this->user->markEmailAsVerified();
         }
 
-        return $user;
+        return $this->user;
     }
 
     /**
      * Create the user.
      *
      * @param array $data
-     *
-     * @return User
      */
-    private function createUser(array $data): User
+    private function createUser(array $data): void
     {
         $uuid = Str::uuid()->toString();
 
-        $user = User::create([
+        $this->user = User::create([
             'email' => $data['email'],
             'password' => Hash::make($data['password']),
             'first_name' => $this->valueOrNull($data, 'first_name'),
@@ -89,7 +87,5 @@ class CreateAccount extends BaseService implements CreatesNewUsers
             'nickname' => $this->valueOrNull($data, 'nickname'),
             'uuid' => $uuid,
         ]);
-
-        return $user;
     }
 }


### PR DESCRIPTION
I have NO idea how it's possible, but somehow the verification email is sent twice during registration.

When I delete the line where we send the email ourself, the email is only sent twice.

So it fixes the bug. BUT...

As the line to send the email is deleted, why do we still send the email? I think it's because of Fortify somehow. I've read the entire Fortify codebase but I don't see anywhere how come it sends an email.

So. The bug is fixed but I don't know why the app keeps sending the email.