### PR TITLE
style: remove support default email admin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,8 +52,7 @@ MAIL_FROM_ADDRESS=
 MAIL_FROM_NAME=OfficeLife
 
 # Email of the instance administrator that is used for system emails
-# Do not update if you don't know what this does
-EMAIL_INSTANCE_ADMINISTRATOR=support@officelife.io
+EMAIL_INSTANCE_ADMINISTRATOR=your@address.com
 
 MIX_PUSHER_APP_KEY="${PUSHER_APP_KEY}"
 MIX_PUSHER_APP_CLUSTER="${PUSHER_APP_CLUSTER}"

--- a/config/officelife.php
+++ b/config/officelife.php
@@ -40,10 +40,10 @@ return [
     | Email address of the system administrators of the instance
     |--------------------------------------------------------------------------
     |
-    | This defines the name of the site.
+    | This defines the email address of the administrators.
     |
     */
-    'email_instance_administrator' => env('EMAIL_INSTANCE_ADMINISTRATOR', 'support@officelife.io'),
+    'email_instance_administrator' => env('EMAIL_INSTANCE_ADMINISTRATOR'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
support@officelife.io should not be used as a default email administrator value for every person that will use the project.
The value of EMAIL_INSTANCE_ADMINISTRATOR must be set on each instance with a proper value, but we must not get emails from every instance!

You fool, don't forget these steps:

- [ ] Unit tests
- [ ] Tests with Cypress
- [ ] Documentation
- [ ] Dummy data
