### PR TITLE
chore: remove migration that does not work with sqlite

### DIFF
--- a/database/migrations/2014_10_12_200000_add_two_factor_columns_to_users_table.php
+++ b/database/migrations/2014_10_12_200000_add_two_factor_columns_to_users_table.php
@@ -21,14 +21,4 @@ class AddTwoFactorColumnsToUsersTable extends Migration
                     ->nullable();
         });
     }
-
-    /**
-     * Reverse the migrations.
-     */
-    public function down()
-    {
-        Schema::table('users', function (Blueprint $table) {
-            $table->dropColumn('two_factor_secret', 'two_factor_recovery_codes');
-        });
-    }
 }


### PR DESCRIPTION
@asbiin we can't drop two columns in the same migration with sqlite (see https://laravel.com/docs/master/migrations#dropping-columns).

Moreover, there is no need to use `down` methods. We never use them.