### PR TITLE
refactor: remove employee type_translated

### DIFF
--- a/app/Http/Controllers/Company/Adminland/AdminEmployeeStatusController.php
+++ b/app/Http/Controllers/Company/Adminland/AdminEmployeeStatusController.php
@@ -54,12 +54,7 @@ class AdminEmployeeStatusController extends Controller
         $employeeStatus = (new CreateEmployeeStatus)->execute($data);
 
         return response()->json([
-            'data' => [
-                'id' => $employeeStatus->id,
-                'name' => $employeeStatus->name,
-                'type' => $employeeStatus->type,
-                'type_translated' => trans('account.employee_statuses_'.$employeeStatus->type),
-            ],
+            'data' => AdminEmployeeStatusViewHelper::show($employeeStatus),
         ], 201);
     }
 
@@ -86,12 +81,7 @@ class AdminEmployeeStatusController extends Controller
         $employeeStatus = (new UpdateEmployeeStatus)->execute($data);
 
         return response()->json([
-            'data' => [
-                'id' => $employeeStatus->id,
-                'name' => $employeeStatus->name,
-                'type' => $employeeStatus->type,
-                'type_translated' => trans('account.employee_statuses_'.$employeeStatus->type),
-            ],
+            'data' => AdminEmployeeStatusViewHelper::show($employeeStatus),
         ], 200);
     }
 

--- a/app/Http/ViewHelpers/Adminland/AdminEmployeeStatusViewHelper.php
+++ b/app/Http/ViewHelpers/Adminland/AdminEmployeeStatusViewHelper.php
@@ -4,6 +4,7 @@ namespace App\Http\ViewHelpers\Adminland;
 
 use App\Models\Company\Company;
 use Illuminate\Support\Collection;
+use App\Models\Company\EmployeeStatus;
 
 class AdminEmployeeStatusViewHelper
 {
@@ -16,20 +17,26 @@ class AdminEmployeeStatusViewHelper
      */
     public static function index(Company $company): Collection
     {
-        $employeeStatuses = $company->employeeStatuses()
+        return $company->employeeStatuses()
             ->orderBy('name', 'asc')
-            ->get();
+            ->get()
+            ->map(function ($status) {
+                return self::show($status);
+            });
+    }
 
-        $statusesCollection = collect([]);
-        foreach ($employeeStatuses as $status) {
-            $statusesCollection->push([
-                'id' => $status->id,
-                'name' => $status->name,
-                'type' => $status->type,
-                'type_translated' => trans('account.employee_statuses_'.$status->type),
-            ]);
-        }
-
-        return $statusesCollection;
+    /**
+     * Get information about one employee status.
+     *
+     * @param EmployeeStatus $employeeStatus
+     * @return array
+     */
+    public static function show(EmployeeStatus $employeeStatus): array
+    {
+        return [
+            'id' => $employeeStatus->id,
+            'name' => $employeeStatus->name,
+            'type' => $employeeStatus->type,
+        ];
     }
 }

--- a/resources/js/Pages/Adminland/EmployeeStatus/Index.vue
+++ b/resources/js/Pages/Adminland/EmployeeStatus/Index.vue
@@ -103,7 +103,7 @@
           <ul v-show="localStatuses.length != 0" class="list pl0 mv0 center ba br2 bb-gray" data-cy="statuses-list" :data-cy-items="localStatuses.map(n => n.id)">
             <li v-for="status in localStatuses" :key="status.id" class="pv3 ph2 bb bb-gray bb-gray-hover" :data-cy="'status-item-' + status.id">
               <div v-if="idToUpdate != status.id" class="di">
-                {{ status.name }} <span class="type">{{ status.type_translated }}</span>
+                {{ status.name }} <span class="type">{{ $t('account.employee_statuses_'+status.type) }}</span>
               </div>
 
               <!-- UPDATE POSITION FORM -->

--- a/tests/Unit/ViewHelpers/Adminland/AdminEmployeeStatusViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Adminland/AdminEmployeeStatusViewHelperTest.php
@@ -26,7 +26,6 @@ class AdminEmployeeStatusViewHelperTest extends TestCase
                     'id' => $status->id,
                     'name' => 'Permanent',
                     'type' => 'internal',
-                    'type_translated' => 'internal',
                 ],
             ],
             $collection->toArray()


### PR DESCRIPTION
Another refactor.

@djaiss see how AdminEmployeeStatusViewHelper::index is easy to read now.


You fool, don't forget these steps:

- [ ] Unit tests
- [ ] Tests with Cypress
- [ ] Documentation
- [ ] Dummy data
