### PR TITLE
refactor: simplify queuable service

### DIFF
--- a/app/Jobs/ServiceQueue.php
+++ b/app/Jobs/ServiceQueue.php
@@ -23,6 +23,13 @@ class ServiceQueue implements ShouldQueue
     public QueuableService $service;
 
     /**
+     * The number of times the job may be attempted.
+     *
+     * @var int
+     */
+    public $tries = 1;
+
+    /**
      * Create a new job instance.
      *
      * @param BaseService $service
@@ -40,11 +47,7 @@ class ServiceQueue implements ShouldQueue
      */
     public function handle(): void
     {
-        try {
-            $this->service->handle();
-        } catch (\Exception $e) {
-            $this->fail($e);
-        }
+        $this->service->handle();
     }
 
     /**

--- a/app/Services/Company/Adminland/Employee/ImportEmployeesFromCSV.php
+++ b/app/Services/Company/Adminland/Employee/ImportEmployeesFromCSV.php
@@ -43,43 +43,10 @@ class ImportEmployeesFromCSV extends BaseService implements QueuableService
 
     /**
      * Read the CSV file and put rows in the temporary table.
-     *
-     * @param array $data
-     */
-    public function init(array $data = []): self
-    {
-        $this->data = $data;
-        $this->validate();
-
-        return $this;
-    }
-
-    private function validate(): array
-    {
-        $this->validateRules($this->data);
-
-        $this->author($this->data['author_id'])
-            ->inCompany($this->data['company_id'])
-            ->asAtLeastHR()
-            ->canExecuteService();
-
-        $importJob = ImportJob::where('company_id', $this->data['company_id'])
-            ->findOrFail($this->data['import_job_id']);
-
-        $file = File::where('company_id', $this->data['company_id'])
-            ->findOrFail($this->data['file_id']);
-
-        return [$importJob, $file];
-    }
-
-    /**
-     * Import the employees.
      */
     public function handle(): void
     {
-        [$importJob, $file] = $this->validate();
-        $this->importJob = $importJob;
-        $this->file = $file;
+        $this->validate();
 
         $this->importJob->update([
             'status' => ImportJob::STARTED,
@@ -94,6 +61,22 @@ class ImportEmployeesFromCSV extends BaseService implements QueuableService
         ]);
     }
 
+    private function validate(): void
+    {
+        $this->validateRules($this->data);
+
+        $this->author($this->data['author_id'])
+            ->inCompany($this->data['company_id'])
+            ->asAtLeastHR()
+            ->canExecuteService();
+
+        $this->importJob = ImportJob::where('company_id', $this->data['company_id'])
+            ->findOrFail($this->data['import_job_id']);
+
+        $this->file = File::where('company_id', $this->data['company_id'])
+            ->findOrFail($this->data['file_id']);
+    }
+
     /**
      * Handle a job failure.
      *
@@ -101,6 +84,10 @@ class ImportEmployeesFromCSV extends BaseService implements QueuableService
      */
     public function failed(Throwable $exception): void
     {
+        if (! isset($this->importJob)) {
+            $this->importJob = ImportJob::where('company_id', $this->data['company_id'])
+                ->find($this->data['import_job_id']);
+        }
         if ($this->importJob !== null) {
             $this->importJob->update([
                 'status' => ImportJob::FAILED,

--- a/app/Services/Company/Adminland/Employee/ImportEmployeesFromCSV.php
+++ b/app/Services/Company/Adminland/Employee/ImportEmployeesFromCSV.php
@@ -22,7 +22,10 @@ class ImportEmployeesFromCSV extends BaseService implements QueuableService
 
     private array $data;
 
-    private ImportJob $importJob;
+    /**
+     * @var ImportJob|null
+     */
+    private ?ImportJob $importJob = null;
 
     private File $file;
 
@@ -84,7 +87,7 @@ class ImportEmployeesFromCSV extends BaseService implements QueuableService
      */
     public function failed(Throwable $exception): void
     {
-        if (! isset($this->importJob)) {
+        if ($this->importJob === null) {
             $this->importJob = ImportJob::where('company_id', $this->data['company_id'])
                 ->find($this->data['import_job_id']);
         }

--- a/app/Services/Company/Adminland/Employee/ImportEmployeesFromTemporaryTable.php
+++ b/app/Services/Company/Adminland/Employee/ImportEmployeesFromTemporaryTable.php
@@ -6,6 +6,7 @@ use Throwable;
 use App\Services\BaseService;
 use App\Models\Company\ImportJob;
 use App\Services\QueuableService;
+use App\Jobs\AddEmployeeToCompany;
 use App\Services\DispatchableService;
 use App\Models\Company\ImportJobReport;
 

--- a/app/Services/Company/Adminland/Employee/ImportEmployeesFromTemporaryTable.php
+++ b/app/Services/Company/Adminland/Employee/ImportEmployeesFromTemporaryTable.php
@@ -16,7 +16,10 @@ class ImportEmployeesFromTemporaryTable extends BaseService implements QueuableS
 
     private array $data;
 
-    private ImportJob $importJob;
+    /**
+     * @var ImportJob|null
+     */
+    private ?ImportJob $importJob = null;
 
     /**
      * Get the validation rules that apply to the service.
@@ -93,7 +96,7 @@ class ImportEmployeesFromTemporaryTable extends BaseService implements QueuableS
      */
     public function failed(Throwable $exception): void
     {
-        if (! isset($this->importJob)) {
+        if ($this->importJob === null) {
             $this->importJob = ImportJob::where('company_id', $this->data['company_id'])
                 ->find($this->data['import_job_id']);
         }

--- a/app/Services/Company/Group/AddEmployeeToGroup.php
+++ b/app/Services/Company/Group/AddEmployeeToGroup.php
@@ -38,29 +38,11 @@ class AddEmployeeToGroup extends BaseService implements QueuableService
     }
 
     /**
-     * Initialize service.
-     *
-     * @param array $data
-     * @return self
-     */
-    public function init(array $data = []): self
-    {
-        $this->data = $data;
-        $this->validate();
-
-        return $this;
-    }
-
-    /**
      * Add an employee to a group.
-     *
-     * @return void
      */
     public function handle(): void
     {
-        [$employee, $group] = $this->validate();
-        $this->employee = $employee;
-        $this->group = $group;
+        $this->validate();
 
         $this->attachEmployee();
         $this->log();
@@ -79,7 +61,7 @@ class AddEmployeeToGroup extends BaseService implements QueuableService
         return $this->employee;
     }
 
-    private function validate(): array
+    private function validate(): void
     {
         $this->validateRules($this->data);
 
@@ -88,12 +70,10 @@ class AddEmployeeToGroup extends BaseService implements QueuableService
             ->asNormalUser()
             ->canExecuteService();
 
-        $employee = $this->validateEmployeeBelongsToCompany($this->data);
+        $this->employee = $this->validateEmployeeBelongsToCompany($this->data);
 
-        $group = Group::where('company_id', $this->data['company_id'])
+        $this->group = Group::where('company_id', $this->data['company_id'])
             ->findOrFail($this->data['group_id']);
-
-        return [$employee, $group];
     }
 
     private function attachEmployee(): void

--- a/app/Services/DispatchableService.php
+++ b/app/Services/DispatchableService.php
@@ -11,7 +11,12 @@ use Illuminate\Foundation\Bus\PendingDispatch;
  */
 trait DispatchableService
 {
-    final public function __construct(array $data = [])
+    /**
+     * Create a new service.
+     *
+     * @param array $data
+     */
+    public function __construct(array $data = [])
     {
         $this->data = $data;
     }
@@ -25,7 +30,7 @@ trait DispatchableService
     public static function dispatch(...$arguments): PendingDispatch
     {
         /** @var QueuableService $service */
-        $service = new static(...$arguments);
+        $service = new self(...$arguments);
         return ServiceQueue::dispatch($service);
     }
 
@@ -38,7 +43,7 @@ trait DispatchableService
     public static function dispatchSync(...$arguments): mixed
     {
         /** @var QueuableService $service */
-        $service = new static(...$arguments);
+        $service = new self(...$arguments);
         return ServiceQueue::dispatchSync($service);
     }
 

--- a/app/Services/DispatchableService.php
+++ b/app/Services/DispatchableService.php
@@ -11,8 +11,9 @@ use Illuminate\Foundation\Bus\PendingDispatch;
  */
 trait DispatchableService
 {
-    final public function __construct()
+    final public function __construct(array $data = [])
     {
+        $this->data = $data;
     }
 
     /**
@@ -24,13 +25,12 @@ trait DispatchableService
     public static function dispatch(...$arguments): PendingDispatch
     {
         /** @var QueuableService $service */
-        $service = new static();
-        $service->init(...$arguments);
+        $service = new static(...$arguments);
         return ServiceQueue::dispatch($service);
     }
 
     /**
-     * Dispatch the service with the given arguments.
+     * Dispatch the service with the given arguments on the sync queue.
      *
      * @param  mixed  ...$arguments
      * @return mixed
@@ -38,8 +38,7 @@ trait DispatchableService
     public static function dispatchSync(...$arguments): mixed
     {
         /** @var QueuableService $service */
-        $service = new static();
-        $service->init(...$arguments);
+        $service = new static(...$arguments);
         return ServiceQueue::dispatchSync($service);
     }
 

--- a/app/Services/QueuableService.php
+++ b/app/Services/QueuableService.php
@@ -10,13 +10,6 @@ use Throwable;
 interface QueuableService
 {
     /**
-     * Initialize the service.
-     *
-     * @param array $data
-     */
-    public function init(array $data = []): self;
-
-    /**
      * Execute the service.
      */
     public function handle(): void;

--- a/tests/Unit/Jobs/ServiceQueueTest.php
+++ b/tests/Unit/Jobs/ServiceQueueTest.php
@@ -16,7 +16,7 @@ class ServiceQueueTest extends TestCase
     {
         config(['queue.default' => 'sync']);
 
-        ServiceQueueTester::dispatchSync();
+        ServiceQueueTester::dispatch();
 
         $this->assertTrue(ServiceQueueTester::$executed);
         $this->assertFalse(ServiceQueueTester::$failed);
@@ -27,7 +27,7 @@ class ServiceQueueTest extends TestCase
     {
         config(['queue.default' => 'sync']);
 
-        ServiceQueueTester::dispatchSync(['throw' => true]);
+        ServiceQueueTester::dispatch(['throw' => true]);
 
         $this->assertTrue(ServiceQueueTester::$executed);
         $this->assertTrue(ServiceQueueTester::$failed);

--- a/tests/Unit/Jobs/ServiceQueueTest.php
+++ b/tests/Unit/Jobs/ServiceQueueTest.php
@@ -23,14 +23,35 @@ class ServiceQueueTest extends TestCase
     }
 
     /** @test */
+    public function it_run_a_service_sync(): void
+    {
+        ServiceQueueTester::dispatchSync();
+
+        $this->assertTrue(ServiceQueueTester::$executed);
+        $this->assertFalse(ServiceQueueTester::$failed);
+    }
+
+    /** @test */
     public function it_run_a_service_which_failed(): void
     {
-        config(['queue.default' => 'sync']);
+        $this->expectException(\Exception::class);
+        try {
+            ServiceQueueTester::dispatchSync(['throw' => true]);
+        } finally {
+            $this->assertTrue(ServiceQueueTester::$executed);
+            $this->assertTrue(ServiceQueueTester::$failed);
+        }
+    }
+
+    /** @test */
+    public function service_is_not_run_if_queue_set(): void
+    {
+        config(['queue.default' => 'database']);
 
         ServiceQueueTester::dispatch(['throw' => true]);
 
-        $this->assertTrue(ServiceQueueTester::$executed);
-        $this->assertTrue(ServiceQueueTester::$failed);
+        $this->assertFalse(ServiceQueueTester::$executed);
+        $this->assertFalse(ServiceQueueTester::$failed);
     }
 
     /** @test */

--- a/tests/Unit/Jobs/ServiceQueueTester.php
+++ b/tests/Unit/Jobs/ServiceQueueTester.php
@@ -15,18 +15,18 @@ class ServiceQueueTester extends BaseService implements QueuableService
     public static bool $executed = false;
     public static bool $failed = false;
 
+    public bool $object;
+
     /**
      * Initialize the service.
      *
      * @param array $data
      */
-    public function init(array $data = []): self
+    public function __construct(array $data = [])
     {
         $this->data = $data;
         self::$executed = false;
         self::$failed = false;
-
-        return $this;
     }
 
     /**
@@ -49,5 +49,9 @@ class ServiceQueueTester extends BaseService implements QueuableService
     public function failed(Throwable $exception): void
     {
         self::$failed = true;
+
+        if (isset($this->obj)) {
+            // variable can be touch
+        }
     }
 }

--- a/tests/Unit/Services/Company/Adminland/Employee/ImportEmployeesFromCSVTest.php
+++ b/tests/Unit/Services/Company/Adminland/Employee/ImportEmployeesFromCSVTest.php
@@ -107,7 +107,7 @@ class ImportEmployeesFromCSVTest extends TestCase
         ];
 
         $this->expectException(RequestException::class);
-        (new ImportEmployeesFromCSV)->init($request)->handle();
+        (new ImportEmployeesFromCSV($request))->handle();
     }
 
     /** @test */
@@ -121,7 +121,7 @@ class ImportEmployeesFromCSVTest extends TestCase
         ];
 
         $this->expectException(ValidationException::class);
-        (new ImportEmployeesFromCSV)->init($request)->handle();
+        (new ImportEmployeesFromCSV($request))->handle();
     }
 
     private function executeService(Employee $michael, ImportJob $importJob, File $file): void
@@ -140,7 +140,7 @@ class ImportEmployeesFromCSVTest extends TestCase
             'file_id' => $file->id,
         ];
 
-        (new ImportEmployeesFromCSV)->init($request)->handle();
+        (new ImportEmployeesFromCSV($request))->handle();
 
         $this->assertDatabaseHas('import_job_reports', [
             'import_job_id' => $importJob->id,

--- a/tests/Unit/Services/Company/Adminland/Employee/ImportEmployeesFromCSVTest.php
+++ b/tests/Unit/Services/Company/Adminland/Employee/ImportEmployeesFromCSVTest.php
@@ -124,6 +124,40 @@ class ImportEmployeesFromCSVTest extends TestCase
         (new ImportEmployeesFromCSV($request))->handle();
     }
 
+    /** @test */
+    public function it_save_state_when_failing(): void
+    {
+        $michael = $this->createEmployee();
+        $importJob = ImportJob::factory()->create([
+            'company_id' => $michael->company_id,
+        ]);
+        $report = ImportJobReport::factory()->create([
+            'import_job_id' => $importJob->id,
+        ]);
+        $file = File::factory()->create([
+            'company_id' => $michael->company_id,
+            'cdn_url' => 'http://url.com/',
+            'name' => 'working.csv',
+        ]);
+
+        $request = [
+            'company_id' => $michael->company_id,
+            'author_id' => $michael->id,
+            'import_job_id' => $importJob->id,
+            'file_id' => $file->id,
+        ];
+
+        try {
+            $this->expectException(NotEnoughPermissionException::class);
+            ImportEmployeesFromCSV::dispatch($request);
+        } finally {
+            $this->assertDatabaseHas('import_jobs', [
+                'id' => $importJob->id,
+                'status' => 'failed',
+            ]);
+        }
+    }
+
     private function executeService(Employee $michael, ImportJob $importJob, File $file): void
     {
         Storage::fake('local');

--- a/tests/Unit/Services/Company/Adminland/Employee/ImportEmployeesFromTemporaryTableTest.php
+++ b/tests/Unit/Services/Company/Adminland/Employee/ImportEmployeesFromTemporaryTableTest.php
@@ -3,15 +3,14 @@
 namespace Tests\Unit\Services\Company\Adminland\Employee;
 
 use Tests\TestCase;
-use App\Jobs\ServiceQueue;
 use App\Models\Company\Employee;
 use App\Models\Company\ImportJob;
+use App\Jobs\AddEmployeeToCompany;
 use Illuminate\Support\Facades\Queue;
 use App\Models\Company\ImportJobReport;
 use Illuminate\Validation\ValidationException;
 use App\Exceptions\NotEnoughPermissionException;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
-use App\Services\Company\Adminland\Employee\AddEmployeeToCompany;
 use App\Services\Company\Adminland\Employee\ImportEmployeesFromTemporaryTable;
 
 class ImportEmployeesFromTemporaryTableTest extends TestCase
@@ -91,9 +90,6 @@ class ImportEmployeesFromTemporaryTableTest extends TestCase
             'status' => ImportJob::IMPORTED,
         ]);
 
-        Queue::assertPushed(ServiceQueue::class, function ($service) {
-            return $service instanceof ServiceQueue
-                && $service->service instanceof AddEmployeeToCompany;
-        });
+        Queue::assertPushed(AddEmployeeToCompany::class);
     }
 }

--- a/tests/Unit/Services/Company/Group/AddEmployeeToGroupTest.php
+++ b/tests/Unit/Services/Company/Group/AddEmployeeToGroupTest.php
@@ -57,7 +57,7 @@ class AddEmployeeToGroupTest extends TestCase
         ];
 
         $this->expectException(ValidationException::class);
-        (new AddEmployeeToGroup)->init($request);
+        (new AddEmployeeToGroup)->execute($request);
     }
 
     /** @test */


### PR DESCRIPTION
This makes the QueuableService implementation even easier

You can call a service with
```
Service::dispatch($data);
```

or

```
(new Service($data))->handle();
```

If you need to get a result, the service can also implement another function like:
```
$result = (new Service)->execute($data);
```
or even
```
$result = (new Service($data))->execute();
```

It also simplify the workflow of calling validate twice ... if a service run on the queue, the validation only happens on the queue run (like before with specific jobs)
So we don't need the `init(array $data)` function anymore, and the trick with `validate()` that return an array (that was a bad idea).

Implementing this to transform an existing service is then really easy:
1. add `implements QueuableService`
2. add `use Dispatchable`

3.a. if `execute()` return something useful
- add `handle` function that take appr. the code of `execute` (without the return)
- change execute with something like:
    ```
    public function execute(array $data): Object
    {
        $this->data = $data;
        $this->handle();
        return $this->object;
    }
    ```

3.b. if `execute()` does not return anything
- rename `execute` to `handle`


You fool, don't forget these steps:

- [x] Unit tests
- [ ] Tests with Cypress
- [ ] Documentation
- [ ] Dummy data
