### PR TITLE
fix: fix illustration on expense hiding help text

### DIFF
--- a/resources/js/Pages/Dashboard/Me/Partials/Expense.vue
+++ b/resources/js/Pages/Dashboard/Me/Partials/Expense.vue
@@ -40,7 +40,7 @@
     </div>
 
     <div class="cf mw7 center br3 mb3 bg-white box pa3 relative">
-      <img loading="lazy" src="/img/dashboard/question_expense.png" alt="a group taking a selfie" class="absolute-ns di-ns dn right-1" :class="addMode ? 'dn' : 'di-ns'" />
+      <img loading="lazy" src="/img/dashboard/question_expense.png" alt="a group taking a selfie" class="absolute-ns right-1" :class="addMode ? 'dn' : 'di-ns'" />
 
       <p v-if="!addMode" class="lh-copy measure">{{ $t('dashboard.expense_show_description') }}</p>
 


### PR DESCRIPTION
<img width="820" alt="image" src="https://user-images.githubusercontent.com/61099/121788892-44d54c00-cb9f-11eb-9283-2cfdd0255b56.png">
