### PR TITLE
fix: ability to use money with different minorUnit

### DIFF
--- a/app/Helpers/MoneyHelper.php
+++ b/app/Helpers/MoneyHelper.php
@@ -4,7 +4,9 @@ namespace App\Helpers;
 
 use Money\Money;
 use Money\Currency;
+use Illuminate\Support\Facades\App;
 use Money\Currencies\ISOCurrencies;
+use Money\Parser\DecimalMoneyParser;
 use Money\Formatter\IntlMoneyFormatter;
 
 class MoneyHelper
@@ -14,17 +16,33 @@ class MoneyHelper
      *
      * @param integer $amount
      * @param string $currency
-     * @param string $locale
+     * @param string|null $locale
      * @return string|null
      */
-    public static function format(int $amount, string $currency, string $locale = 'en_US'): ?string
+    public static function format(int $amount, string $currency, ?string $locale = null): ?string
     {
         $money = new Money($amount, new Currency($currency));
         $currencies = new ISOCurrencies();
 
-        $numberFormatter = new \NumberFormatter($locale, \NumberFormatter::CURRENCY);
+        $numberFormatter = new \NumberFormatter($locale ?? App::getLocale(), \NumberFormatter::CURRENCY);
         $moneyFormatter = new IntlMoneyFormatter($numberFormatter, $currencies);
 
         return $moneyFormatter->format($money);
+    }
+
+    /**
+     * Parse a monetary exchange value as storable integer.
+     * Currency is used to know the precision of this currency.
+     *
+     * @param string $exchange  Amount value in exchange format (ex: 1.00).
+     * @param string $currency
+     * @return int  amount as storable format (ex: 14500)
+     */
+    public static function parseInput(string $exchange, string $currency): int
+    {
+        $moneyParser = new DecimalMoneyParser(new ISOCurrencies());
+        $money = $moneyParser->parse((string) $exchange, new Currency($currency));
+
+        return (int) $money->getAmount();
     }
 }

--- a/app/Helpers/MoneyHelper.php
+++ b/app/Helpers/MoneyHelper.php
@@ -41,7 +41,7 @@ class MoneyHelper
     public static function parseInput(string $exchange, string $currency): int
     {
         $moneyParser = new DecimalMoneyParser(new ISOCurrencies());
-        $money = $moneyParser->parse((string) $exchange, new Currency($currency));
+        $money = $moneyParser->parse($exchange, new Currency($currency));
 
         return (int) $money->getAmount();
     }

--- a/app/Http/Controllers/Company/Dashboard/Me/DashboardMeExpenseController.php
+++ b/app/Http/Controllers/Company/Dashboard/Me/DashboardMeExpenseController.php
@@ -31,7 +31,7 @@ class DashboardMeExpenseController extends Controller
             'company_id' => $company->id,
             'expense_category_id' => $request->input('category'),
             'title' => $request->input('title'),
-            'amount' => $request->input('amount') * 100,
+            'amount' => MoneyHelper::parseInput($request->input('amount'), $request->input('currency')),
             'currency' => $request->input('currency'),
             'description' => $request->input('description'),
             'expensed_at' => Carbon::now()->format('Y-m-d'),

--- a/tests/Unit/Helpers/MoneyHelperTest.php
+++ b/tests/Unit/Helpers/MoneyHelperTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit\Helpers;
 
 use Tests\TestCase;
 use App\Helpers\MoneyHelper;
+use Illuminate\Support\Facades\App;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 
 class MoneyHelperTest extends TestCase
@@ -24,5 +25,29 @@ class MoneyHelperTest extends TestCase
             '132,40 €',
             $number
         );
+    }
+
+    /** @test */
+    public function it_returns_the_amount_with_the_currency_symbol_in_the_right_locale()
+    {
+        App::setLocale('fr');
+
+        $this->assertEquals('500,00 €', MoneyHelper::format(50000, 'EUR'));
+        $this->assertEquals('5 038,29 €', MoneyHelper::format(503829, 'EUR'));
+    }
+
+    /** @test */
+    public function it_parse_an_input_value_eur()
+    {
+        $this->assertEquals(50000, MoneyHelper::parseInput('500.00', 'EUR'));
+        $this->assertEquals(503829, MoneyHelper::parseInput('5038.29', 'EUR'));
+    }
+
+    /** @test */
+    public function it_parse_an_input_value_yen()
+    {
+        $this->assertEquals(500, MoneyHelper::parseInput('500', 'JPY'));
+        $this->assertEquals(5038, MoneyHelper::parseInput('5038', 'JPY'));
+        $this->assertEquals(5038, MoneyHelper::parseInput('5038.00', 'JPY'));
     }
 }


### PR DESCRIPTION
All money don't use 2 minorUnit (2 cents numbers).
`MoneyHelper::parseInput` helps to parse the input

You fool, don't forget these steps:

- [ ] Unit tests
- [ ] Tests with Cypress
- [ ] Documentation
- [ ] Dummy data
