### PR TITLE
feat: add remaining characters left in input text fields

### DIFF
--- a/resources/js/Pages/Adminland/CompanyNews/Create.vue
+++ b/resources/js/Pages/Adminland/CompanyNews/Create.vue
@@ -47,6 +47,7 @@ input[type=radio] {
                         :label="$t('account.company_news_new_title')"
                         :help="$t('account.company_news_new_title_help')"
                         :required="true"
+                        :maxlength="191"
             />
 
             <!-- Content -->

--- a/resources/js/Shared/TextInput.vue
+++ b/resources/js/Shared/TextInput.vue
@@ -58,7 +58,7 @@
              @keydown.esc="sendEscKey"
              @keydown.enter="sendEnterKey"
       />
-      <span class="length absolute f7 br2">
+      <span v-if="maxlength" class="length absolute f7 br2">
         {{ charactersLeft }}
       </span>
     </div>
@@ -188,18 +188,21 @@ export default {
     },
 
     charactersLeft() {
+      var char = 0;
       if (this.proxyValue) {
-        var char = this.proxyValue.length;
-      } else {
-        var char = 0;
+        char = this.proxyValue.length;
       }
 
-      return this.maxlength - char + '/' + this.maxlength;
+      return `${this.maxlength - char} / ${this.maxlength}`;
     },
   },
 
   created() {
-    this.classes = this.defaultClass + ' counter';
+    this.classes = this.defaultClass;
+
+    if (this.maxlength) {
+      this.classes = this.classes + ' counter';
+    }
   },
 
   methods: {

--- a/resources/js/Shared/TextInput.vue
+++ b/resources/js/Shared/TextInput.vue
@@ -18,6 +18,16 @@
   padding: 3px 4px;
 }
 
+.length {
+  top: 10px;
+  right: 10px;
+  background-color: #e5eeff;
+  padding: 3px 4px;
+}
+
+.counter {
+  padding-right: 64px;
+}
 </style>
 
 <template>
@@ -28,23 +38,31 @@
         {{ $t('app.optional') }}
       </span>
     </label>
-    <input :id="realId"
-           :ref="customRef"
-           v-model="proxyValue"
-           :class="defaultClass"
-           :required="required"
-           :type="type"
-           :name="name"
-           :autofocus="autofocus"
-           :step="step"
-           :max="max"
-           :min="min"
-           :placeholder="placeholder"
-           :data-cy="datacy"
-           v-bind="$attrs"
-           @keydown.esc="sendEscKey"
-           @keydown.enter="sendEnterKey"
-    />
+
+    <div class="relative">
+      <input :id="realId"
+             :ref="customRef"
+             v-model="proxyValue"
+             :class="classes"
+             :required="required"
+             :type="type"
+             :name="name"
+             :autofocus="autofocus"
+             :step="step"
+             :max="max"
+             :min="min"
+             :placeholder="placeholder"
+             :data-cy="datacy"
+             v-bind="$attrs"
+             :maxlength="maxlength"
+             @keydown.esc="sendEscKey"
+             @keydown.enter="sendEnterKey"
+      />
+      <span class="length absolute f7 br2">
+        {{ charactersLeft }}
+      </span>
+    </div>
+
     <div v-if="hasError" class="error-explanation pa3 ba br3 mt1">
       <template v-if="!arrayError">
         {{ errors }}
@@ -136,7 +154,11 @@ export default {
     autofocus: {
       type: Boolean,
       default: false,
-    }
+    },
+    maxlength: {
+      type: Number,
+      default: null,
+    },
   },
 
   emits: [
@@ -164,6 +186,20 @@ export default {
     arrayError() {
       return _.isArray(this.errors);
     },
+
+    charactersLeft() {
+      if (this.proxyValue) {
+        var char = this.proxyValue.length;
+      } else {
+        var char = 0;
+      }
+
+      return this.maxlength - char + '/' + this.maxlength;
+    },
+  },
+
+  created() {
+    this.classes = this.defaultClass + ' counter';
   },
 
   methods: {


### PR DESCRIPTION
This will be necessary for the Flow feature.

This adds a counter indicating how many characters remain in the input text field.

This appears when we indicate a new props: `maxlength`. When defined, it will show the counter.

![2021-06-18 08 42 39](https://user-images.githubusercontent.com/61099/122562563-35c42300-d011-11eb-953b-062499d04d9c.gif)
