### PR TITLE
fix: fix permissions to edit employee contract info

### DIFF
--- a/app/Helpers/PermissionHelper.php
+++ b/app/Helpers/PermissionHelper.php
@@ -178,6 +178,14 @@ class PermissionHelper
         }
         $canEditContractInfoTab = $loggedEmployee->permission_level <= 200;
 
+        // can see the Edit contract info tab when editing the employee
+        $canSeeEditContractInformationTab = false;
+        if ($employee->status) {
+            if ($employee->status->type == EmployeeStatus::EXTERNAL && $canEditContractInfoTab) {
+                $canSeeEditContractInformationTab = true;
+            }
+        }
+
         // can delete work log
         $canDeleteWorkLog = $loggedEmployee->permission_level <= 200;
         if ($loggedEmployee->id == $employee->id) {
@@ -212,6 +220,7 @@ class PermissionHelper
             'can_see_timesheets' => $canSeeTimesheets,
             'can_update_avatar' => $canUpdateAvatar,
             'can_edit_hired_at_information' => $canEditHiredAt,
+            'can_see_edit_contract_information_tab' => $canSeeEditContractInformationTab,
             'can_edit_contract_information' => $canEditContractInfoTab,
             'can_delete_worklog' => $canDeleteWorkLog,
         ];

--- a/resources/js/Pages/Employee/Edit.vue
+++ b/resources/js/Pages/Employee/Edit.vue
@@ -42,7 +42,7 @@
                   {{ $t('employee.edit_information_menu') }}
                 </inertia-link>
               </li>
-              <li v-if="permissions.can_edit_contract_information" class="di mr2">
+              <li v-if="permissions.can_see_edit_contract_information_tab" class="di mr2">
                 <inertia-link :href="'/' + $page.props.auth.company.id + '/employees/' + employee.id + '/contract/edit'" data-cy="menu-contract-link" class="no-underline bb-0 ph3 pv2 ">
                   {{ $t('employee.edit_information_menu_contract') }}
                 </inertia-link>

--- a/tests/Unit/Helpers/PermissionHelperTest.php
+++ b/tests/Unit/Helpers/PermissionHelperTest.php
@@ -838,6 +838,56 @@ class PermissionHelperTest extends TestCase
     }
 
     /** @test */
+    public function it_lets_the_employee_see_the_edit_contract_information_tab(): void
+    {
+        $administrator = Employee::factory()->asAdministrator()->create();
+        $hr = $this->createHR();
+        $employee = $this->createEmployee();
+        $anotherEmployee = $this->createEmployee();
+
+        $permission = PermissionHelper::permissions($administrator, $administrator);
+        $this->assertFalse($permission['can_see_edit_contract_information_tab']);
+
+        $permission = PermissionHelper::permissions($administrator, $hr);
+        $this->assertFalse($permission['can_see_edit_contract_information_tab']);
+
+        $permission = PermissionHelper::permissions($administrator, $employee);
+        $this->assertFalse($permission['can_see_edit_contract_information_tab']);
+
+        $permission = PermissionHelper::permissions($hr, $hr);
+        $this->assertFalse($permission['can_see_edit_contract_information_tab']);
+
+        $permission = PermissionHelper::permissions($hr, $employee);
+        $this->assertFalse($permission['can_see_edit_contract_information_tab']);
+
+        $permission = PermissionHelper::permissions($employee, $employee);
+        $this->assertFalse($permission['can_see_edit_contract_information_tab']);
+
+        $permission = PermissionHelper::permissions($employee, $anotherEmployee);
+        $this->assertFalse($permission['can_see_edit_contract_information_tab']);
+
+        $employee = $this->setEmployeeStatus($employee, EmployeeStatus::EXTERNAL);
+
+        $permission = PermissionHelper::permissions($administrator, $administrator);
+        $this->assertFalse($permission['can_see_edit_contract_information_tab']);
+
+        $permission = PermissionHelper::permissions($administrator, $hr);
+        $this->assertFalse($permission['can_see_edit_contract_information_tab']);
+
+        $permission = PermissionHelper::permissions($administrator, $employee);
+        $this->assertTrue($permission['can_see_edit_contract_information_tab']);
+
+        $permission = PermissionHelper::permissions($hr, $hr);
+        $this->assertFalse($permission['can_see_edit_contract_information_tab']);
+
+        $permission = PermissionHelper::permissions($hr, $employee);
+        $this->assertTrue($permission['can_see_edit_contract_information_tab']);
+
+        $permission = PermissionHelper::permissions($employee, $employee);
+        $this->assertFalse($permission['can_see_edit_contract_information_tab']);
+    }
+
+    /** @test */
     public function it_lets_the_employee_delete_worklog(): void
     {
         $administrator = $this->createAdministrator();


### PR DESCRIPTION
Being able to edit contract info doesn't mean you should be able to see the tab that lets you edit contract info.