### PR TITLE
fix: Fix PhpDoc in project namespace

### DIFF
--- a/app/Http/Controllers/Company/Company/Project/ProjectController.php
+++ b/app/Http/Controllers/Company/Company/Project/ProjectController.php
@@ -37,6 +37,7 @@ class ProjectController extends Controller
      *
      * @param Request $request
      * @param int $companyId
+     *
      * @return Response
      */
     public function index(Request $request, int $companyId): Response
@@ -58,6 +59,7 @@ class ProjectController extends Controller
      * @param Request $request
      * @param int $companyId
      * @param int $projectId
+     *
      * @return Response
      */
     public function show(Request $request, int $companyId, int $projectId): Response
@@ -81,6 +83,7 @@ class ProjectController extends Controller
      * @param Request $request
      * @param int $companyId
      * @param int $projectId
+     *
      * @return JsonResponse
      */
     public function start(Request $request, int $companyId, int $projectId): JsonResponse
@@ -107,6 +110,7 @@ class ProjectController extends Controller
      * @param Request $request
      * @param int $companyId
      * @param int $projectId
+     *
      * @return JsonResponse
      */
     public function pause(Request $request, int $companyId, int $projectId): JsonResponse
@@ -133,6 +137,7 @@ class ProjectController extends Controller
      * @param Request $request
      * @param int $companyId
      * @param int $projectId
+     *
      * @return JsonResponse
      */
     public function close(Request $request, int $companyId, int $projectId): JsonResponse
@@ -159,6 +164,7 @@ class ProjectController extends Controller
      * @param Request $request
      * @param int $companyId
      * @param int $projectId
+     *
      * @return Response
      */
     public function edit(Request $request, int $companyId, int $projectId): Response
@@ -177,6 +183,7 @@ class ProjectController extends Controller
      * @param Request $request
      * @param int $companyId
      * @param int $projectId
+     *
      * @return JsonResponse
      */
     public function update(Request $request, int $companyId, int $projectId): JsonResponse
@@ -218,6 +225,7 @@ class ProjectController extends Controller
      * @param Request $request
      * @param int $companyId
      * @param int $projectId
+     *
      * @return JsonResponse
      */
     public function description(Request $request, int $companyId, int $projectId): JsonResponse
@@ -249,7 +257,7 @@ class ProjectController extends Controller
      * @param int $companyId
      * @param int $projectId
      *
-     * @return \Illuminate\Http\RedirectResponse|\Illuminate\Routing\Redirector|Response
+     * @return \Illuminate\Http\RedirectResponse|Response
      */
     public function delete(Request $request, int $companyId, int $projectId)
     {
@@ -276,6 +284,7 @@ class ProjectController extends Controller
      * @param Request $request
      * @param int $companyId
      * @param int $projectId
+     *
      * @return JsonResponse
      */
     public function destroy(Request $request, int $companyId, int $projectId): JsonResponse
@@ -307,6 +316,7 @@ class ProjectController extends Controller
      * @param Request $request
      * @param int $companyId
      * @param int $projectId
+     *
      * @return JsonResponse
      */
     public function assign(Request $request, int $companyId, int $projectId): JsonResponse
@@ -351,6 +361,7 @@ class ProjectController extends Controller
      * @param Request $request
      * @param int $companyId
      * @param int $projectId
+     *
      * @return JsonResponse
      */
     public function clear(Request $request, int $companyId, int $projectId): JsonResponse
@@ -381,6 +392,7 @@ class ProjectController extends Controller
      *
      * @param Request $request
      * @param int $companyId
+     *
      * @return Response
      */
     public function create(Request $request, int $companyId): Response
@@ -395,6 +407,7 @@ class ProjectController extends Controller
      *
      * @param Request $request
      * @param int $companyId
+     *
      * @return JsonResponse
      */
     public function search(Request $request, int $companyId): JsonResponse
@@ -412,6 +425,7 @@ class ProjectController extends Controller
      *
      * @param Request $request
      * @param int $companyId
+     *
      * @return JsonResponse
      */
     public function store(Request $request, int $companyId): JsonResponse
@@ -454,6 +468,7 @@ class ProjectController extends Controller
      * @param Request $request
      * @param int $companyId
      * @param int $projectId
+     *
      * @return JsonResponse
      */
     public function createLink(Request $request, int $companyId, int $projectId): JsonResponse
@@ -489,6 +504,7 @@ class ProjectController extends Controller
      * @param int $companyId
      * @param int $projectId
      * @param int $linkId
+     *
      * @return JsonResponse
      */
     public function destroyLink(Request $request, int $companyId, int $projectId, int $linkId): JsonResponse
@@ -517,7 +533,7 @@ class ProjectController extends Controller
      * @param int $companyId
      * @param int $projectId
      *
-     * @return \Illuminate\Http\RedirectResponse|\Illuminate\Routing\Redirector|Response
+     * @return \Illuminate\Http\RedirectResponse|Response
      */
     public function createStatus(Request $request, int $companyId, int $projectId)
     {
@@ -547,6 +563,8 @@ class ProjectController extends Controller
      * @param Request $request
      * @param int $companyId
      * @param int $projectId
+     *
+     * @return JsonResponse
      */
     public function postStatus(Request $request, int $companyId, int $projectId)
     {

--- a/app/Http/Controllers/Company/Company/Project/ProjectDecisionsController.php
+++ b/app/Http/Controllers/Company/Company/Project/ProjectDecisionsController.php
@@ -28,6 +28,8 @@ class ProjectDecisionsController extends Controller
      * @param Request $request
      * @param int $companyId
      * @param int $projectId
+     *
+     * @return \Illuminate\Http\RedirectResponse|Response
      */
     public function index(Request $request, int $companyId, int $projectId)
     {
@@ -58,6 +60,7 @@ class ProjectDecisionsController extends Controller
      * @param int $companyId
      * @param int $projectId
      * @param int $decisionId
+     *
      * @return JsonResponse
      */
     public function destroy(Request $request, int $companyId, int $projectId, int $decisionId): JsonResponse
@@ -84,6 +87,7 @@ class ProjectDecisionsController extends Controller
      *
      * @param Request $request
      * @param int $companyId
+     *
      * @return JsonResponse
      */
     public function search(Request $request, int $companyId): JsonResponse
@@ -102,6 +106,7 @@ class ProjectDecisionsController extends Controller
      * @param Request $request
      * @param int $companyId
      * @param int $projectId
+     *
      * @return JsonResponse
      */
     public function store(Request $request, int $companyId, int $projectId): JsonResponse

--- a/app/Http/Controllers/Company/Company/Project/ProjectFilesController.php
+++ b/app/Http/Controllers/Company/Company/Project/ProjectFilesController.php
@@ -29,7 +29,7 @@ class ProjectFilesController extends Controller
      * @param int $companyId
      * @param int $projectId
      *
-     * @return \Illuminate\Http\RedirectResponse|\Illuminate\Routing\Redirector|Response
+     * @return \Illuminate\Http\RedirectResponse|Response
      */
     public function index(Request $request, int $companyId, int $projectId)
     {
@@ -58,6 +58,7 @@ class ProjectFilesController extends Controller
      * @param Request $request
      * @param int $companyId
      * @param int $projectId
+     *
      * @return JsonResponse|null
      */
     public function store(Request $request, int $companyId, int $projectId): ?JsonResponse
@@ -118,6 +119,7 @@ class ProjectFilesController extends Controller
      * @param int $companyId
      * @param int $projectId
      * @param int $fileId
+     *
      * @return JsonResponse|null
      */
     public function destroy(Request $request, int $companyId, int $projectId, int $fileId): ?JsonResponse

--- a/app/Http/Controllers/Company/Company/Project/ProjectMembersController.php
+++ b/app/Http/Controllers/Company/Company/Project/ProjectMembersController.php
@@ -28,7 +28,7 @@ class ProjectMembersController extends Controller
      * @param int $companyId
      * @param int $projectId
      *
-     * @return \Illuminate\Http\RedirectResponse|\Illuminate\Routing\Redirector|Response
+     * @return \Illuminate\Http\RedirectResponse|Response
      */
     public function index(Request $request, int $companyId, int $projectId)
     {
@@ -56,6 +56,7 @@ class ProjectMembersController extends Controller
      * @param Request $request
      * @param int $companyId
      * @param int $projectId
+     *
      * @return JsonResponse
      */
     public function search(Request $request, int $companyId, int $projectId): JsonResponse
@@ -83,6 +84,7 @@ class ProjectMembersController extends Controller
      * @param Request $request
      * @param int $companyId
      * @param int $projectId
+     *
      * @return JsonResponse
      */
     public function store(Request $request, int $companyId, int $projectId): JsonResponse
@@ -126,6 +128,7 @@ class ProjectMembersController extends Controller
      * @param int $companyId
      * @param int $projectId
      * @param int $employeeId
+     *
      * @return JsonResponse
      */
     public function destroy(Request $request, int $companyId, int $projectId, int $employeeId): JsonResponse

--- a/app/Http/Controllers/Company/Company/Project/ProjectMessagesController.php
+++ b/app/Http/Controllers/Company/Company/Project/ProjectMessagesController.php
@@ -28,7 +28,7 @@ class ProjectMessagesController extends Controller
      * @param int $companyId
      * @param int $projectId
      *
-     * @return \Illuminate\Http\RedirectResponse|\Illuminate\Routing\Redirector|Response
+     * @return \Illuminate\Http\RedirectResponse|Response
      */
     public function index(Request $request, int $companyId, int $projectId)
     {
@@ -58,7 +58,7 @@ class ProjectMessagesController extends Controller
      * @param int $companyId
      * @param int $projectId
      *
-     * @return \Illuminate\Http\RedirectResponse|\Illuminate\Routing\Redirector|Response
+     * @return \Illuminate\Http\RedirectResponse|Response
      */
     public function create(Request $request, int $companyId, int $projectId)
     {
@@ -84,6 +84,7 @@ class ProjectMessagesController extends Controller
      * @param Request $request
      * @param int $companyId
      * @param int $projectId
+     *
      * @return JsonResponse
      */
     public function store(Request $request, int $companyId, int $projectId): JsonResponse
@@ -114,7 +115,7 @@ class ProjectMessagesController extends Controller
      * @param int $projectId
      * @param int $messageId
      *
-     * @return \Illuminate\Http\RedirectResponse|\Illuminate\Routing\Redirector|Response
+     * @return \Illuminate\Http\RedirectResponse|Response
      */
     public function show(Request $request, int $companyId, int $projectId, int $messageId)
     {
@@ -160,7 +161,7 @@ class ProjectMessagesController extends Controller
      * @param int $projectId
      * @param int $messageId
      *
-     * @return \Illuminate\Http\RedirectResponse|\Illuminate\Routing\Redirector|Response
+     * @return \Illuminate\Http\RedirectResponse|Response
      */
     public function edit(Request $request, int $companyId, int $projectId, int $messageId)
     {
@@ -197,6 +198,7 @@ class ProjectMessagesController extends Controller
      * @param int $companyId
      * @param int $projectId
      * @param int $projectMessageId
+     *
      * @return JsonResponse
      */
     public function update(Request $request, int $companyId, int $projectId, int $projectMessageId): JsonResponse
@@ -227,6 +229,7 @@ class ProjectMessagesController extends Controller
      * @param int $companyId
      * @param int $projectId
      * @param int $projectMessageId
+     *
      * @return JsonResponse
      */
     public function destroy(Request $request, int $companyId, int $projectId, int $projectMessageId): JsonResponse

--- a/app/Http/Controllers/Company/Company/Project/ProjectTaskListsController.php
+++ b/app/Http/Controllers/Company/Company/Project/ProjectTaskListsController.php
@@ -20,6 +20,7 @@ class ProjectTaskListsController extends Controller
      * @param Request $request
      * @param int $companyId
      * @param int $projectId
+     *
      * @return JsonResponse
      */
     public function store(Request $request, int $companyId, int $projectId): JsonResponse
@@ -49,6 +50,7 @@ class ProjectTaskListsController extends Controller
      * @param int $companyId
      * @param int $projectId
      * @param int $projectTaskListId
+     *
      * @return JsonResponse
      */
     public function update(Request $request, int $companyId, int $projectId, int $projectTaskListId): JsonResponse
@@ -79,6 +81,7 @@ class ProjectTaskListsController extends Controller
      * @param int $companyId
      * @param int $projectId
      * @param int $projectTaskListId
+     *
      * @return JsonResponse
      */
     public function destroy(Request $request, int $companyId, int $projectId, int $projectTaskListId): JsonResponse

--- a/app/Http/Controllers/Company/Company/Project/ProjectTasksController.php
+++ b/app/Http/Controllers/Company/Company/Project/ProjectTasksController.php
@@ -34,7 +34,7 @@ class ProjectTasksController extends Controller
      * @param int $companyId
      * @param int $projectId
      *
-     * @return \Illuminate\Http\RedirectResponse|\Illuminate\Routing\Redirector|Response
+     * @return \Illuminate\Http\RedirectResponse|Response
      */
     public function index(Request $request, int $companyId, int $projectId)
     {
@@ -64,7 +64,7 @@ class ProjectTasksController extends Controller
      * @param int $projectId
      * @param int $taskId
      *
-     * @return \Illuminate\Http\RedirectResponse|\Illuminate\Routing\Redirector|Response
+     * @return \Illuminate\Http\RedirectResponse|Response
      */
     public function show(Request $request, int $companyId, int $projectId, int $taskId)
     {
@@ -103,6 +103,7 @@ class ProjectTasksController extends Controller
      * @param Request $request
      * @param int $companyId
      * @param int $projectId
+     *
      * @return JsonResponse
      */
     public function store(Request $request, int $companyId, int $projectId): JsonResponse
@@ -163,6 +164,7 @@ class ProjectTasksController extends Controller
      * @param int $companyId
      * @param int $projectId
      * @param int $taskId
+     *
      * @return JsonResponse
      */
     public function update(Request $request, int $companyId, int $projectId, int $taskId): JsonResponse
@@ -228,6 +230,7 @@ class ProjectTasksController extends Controller
      * @param int $companyId
      * @param int $projectId
      * @param int $projectTaskId
+     *
      * @return JsonResponse
      */
     public function toggle(Request $request, int $companyId, int $projectId, int $projectTaskId): JsonResponse
@@ -256,6 +259,7 @@ class ProjectTasksController extends Controller
      * @param int $companyId
      * @param int $projectId
      * @param int $taskId
+     *
      * @return JsonResponse
      */
     public function destroy(Request $request, int $companyId, int $projectId, int $taskId): JsonResponse
@@ -284,6 +288,7 @@ class ProjectTasksController extends Controller
      * @param int $companyId
      * @param int $projectId
      * @param int $taskId
+     *
      * @return JsonResponse
      */
     public function timeTrackingEntries(Request $request, int $companyId, int $projectId, int $taskId): JsonResponse
@@ -317,6 +322,7 @@ class ProjectTasksController extends Controller
      * @param int $companyId
      * @param int $projectId
      * @param int $taskId
+     *
      * @return JsonResponse
      */
     public function logTime(Request $request, int $companyId, int $projectId, int $taskId): JsonResponse


### PR DESCRIPTION
PhpDoc Fixed

We don't need to add `Illuminate\Routing\Redirector` in most PHP function docs because `redirect()` helper is never passed blank or null in these files.
