### PR TITLE
fix: fix convertamount format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 .env
 .env.cypress.local
 .phpunit.result.cache
+.php_cs.cache
 .php-cs-fixer.cache
 Homestead.json
 Homestead.yaml

--- a/app/Services/Company/Adminland/Expense/ConvertAmountFromOneCurrencyToCompanyCurrency.php
+++ b/app/Services/Company/Adminland/Expense/ConvertAmountFromOneCurrencyToCompanyCurrency.php
@@ -5,6 +5,7 @@ namespace App\Services\Company\Adminland\Expense;
 use Carbon\Carbon;
 use ErrorException;
 use Illuminate\Support\Str;
+use App\Helpers\MoneyHelper;
 use App\Services\BaseService;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Http;
@@ -118,7 +119,7 @@ class ConvertAmountFromOneCurrencyToCompanyCurrency extends BaseService
 
     private function convert(): void
     {
-        $this->convertedAmount = $this->amount / $this->rate;
+        $this->convertedAmount = MoneyHelper::parseInput((string) ($this->amount / $this->rate), $this->companyCurrency);
     }
 
     /**

--- a/database/migrations/2020_06_30_211833_create_expenses_table.php
+++ b/database/migrations/2020_06_30_211833_create_expenses_table.php
@@ -22,9 +22,9 @@ class CreateExpensesTable extends Migration
             $table->unsignedBigInteger('expense_category_id')->nullable();
             $table->string('status')->default('created');
             $table->string('title');
-            $table->integer('amount');
+            $table->unsignedBigInteger('amount');
             $table->string('currency');
-            $table->double('converted_amount')->nullable();
+            $table->unsignedBigInteger('converted_amount')->nullable();
             $table->string('converted_to_currency')->nullable();
             $table->datetime('converted_at')->nullable();
             $table->double('exchange_rate')->nullable();

--- a/database/migrations/2021_07_13_164157_fix_expense_converted_amount.php
+++ b/database/migrations/2021_07_13_164157_fix_expense_converted_amount.php
@@ -2,6 +2,7 @@
 
 use App\Helpers\MoneyHelper;
 use App\Models\Company\Expense;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
@@ -13,6 +14,12 @@ class FixExpenseConvertedAmount extends Migration
      */
     public function up()
     {
+        /** @var $connection \Illuminate\Database\Connection */
+        $connection = DB::connection();
+        if ($connection->getDriverName() === 'sqlite') {
+            return;
+        }
+
         Expense::whereNotNull('converted_amount')
             ->chunk(100, function ($expenses) {
                 foreach ($expenses as $expense) {

--- a/database/migrations/2021_07_13_164157_fix_expense_converted_amount.php
+++ b/database/migrations/2021_07_13_164157_fix_expense_converted_amount.php
@@ -1,0 +1,29 @@
+<?php
+
+use App\Helpers\MoneyHelper;
+use App\Models\Company\Expense;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class FixExpenseConvertedAmount extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up()
+    {
+        Expense::whereNotNull('converted_amount')
+            ->chunk(100, function ($expenses) {
+                foreach ($expenses as $expense) {
+                    $expense->converted_amount = MoneyHelper::parseInput((string) $expense->converted_amount, $expense->converted_to_currency);
+                    $expense->save();
+                }
+            });
+
+        Schema::table('expenses', function (Blueprint $table) {
+            $table->unsignedBigInteger('amount')->change();
+            $table->unsignedBigInteger('converted_amount')->change();
+        });
+    }
+}

--- a/database/migrations/2021_07_13_164157_fix_expense_converted_amount.php
+++ b/database/migrations/2021_07_13_164157_fix_expense_converted_amount.php
@@ -14,12 +14,6 @@ class FixExpenseConvertedAmount extends Migration
      */
     public function up()
     {
-        /** @var $connection \Illuminate\Database\Connection */
-        $connection = DB::connection();
-        if ($connection->getDriverName() === 'sqlite') {
-            return;
-        }
-
         Expense::whereNotNull('converted_amount')
             ->chunk(100, function ($expenses) {
                 foreach ($expenses as $expense) {
@@ -28,9 +22,13 @@ class FixExpenseConvertedAmount extends Migration
                 }
             });
 
-        Schema::table('expenses', function (Blueprint $table) {
-            $table->unsignedBigInteger('amount')->change();
-            $table->unsignedBigInteger('converted_amount')->change();
-        });
+        /** @var \Illuminate\Database\Connection $connection */
+        $connection = DB::connection();
+        if ($connection->getDriverName() !== 'sqlite') {
+            Schema::table('expenses', function (Blueprint $table) {
+                $table->unsignedBigInteger('amount')->change();
+                $table->unsignedBigInteger('converted_amount')->change();
+            });
+        }
     }
 }

--- a/tests/Unit/Services/Company/Adminland/Expense/ConvertAmountFromOneCurrencyToCompanyCurrencyTest.php
+++ b/tests/Unit/Services/Company/Adminland/Expense/ConvertAmountFromOneCurrencyToCompanyCurrencyTest.php
@@ -45,7 +45,7 @@ class ConvertAmountFromOneCurrencyToCompanyCurrencyTest extends TestCase
         $this->assertEquals(
             [
                 'exchange_rate' => 0.847968,
-                'converted_amount' => 11792.897845201705,
+                'converted_amount' => 1179290,
                 'converted_to_currency' => 'USD',
                 'converted_at' => '2018-01-01 00:00:00',
             ],


### PR DESCRIPTION
Amount **must** **ALWAYS** be saved as integer.
In this case, `converted_amount` is also render later using `MoneyHelper::format()` which take the amount as an integer.

Notes:
- the migration in `2021_07_13_164157_fix_expense_converted_amount.php` use a `change()` which does not work on sqlite (it locks the table!)
- that's why I've updated the columns in `2020_06_30_211833_create_expenses_table.php` also: it will apply for sqlite, or new installation, which is fine, and the migration will not apply to existing installation, which is fine too (the 2nd migration will fix it)
---
Thanks for contributing.

Please make sure your PR follows those guidelines:

- [x] Unit tests for everything.
- [ ] Documentation has been written on the [documentation website](https://github.com/officelifehq/docs).
- [ ] Dummy data in the `SetupDummyAccount` file, so test accounts are populated automatically with fresh data.


