### PR TITLE
feat: automatic slug when creating or renaming a company

### DIFF
--- a/app/Http/ViewHelpers/Adminland/AdminGeneralViewHelper.php
+++ b/app/Http/ViewHelpers/Adminland/AdminGeneralViewHelper.php
@@ -63,6 +63,7 @@ class AdminGeneralViewHelper
         return [
             'id' => $company->id,
             'name' => $name,
+            'slug' => $company->slug,
             'administrators' => $administratorsCollection,
             'creation_date' => $creationDate,
             'currency' => $company->currency,

--- a/app/Models/Company/Company.php
+++ b/app/Models/Company/Company.php
@@ -25,6 +25,7 @@ class Company extends Model
     protected $fillable = [
         'name',
         'currency',
+        'slug',
         'location',
         'has_dummy_data',
         'logo_file_id',

--- a/app/Services/Company/Adminland/Company/CreateCompany.php
+++ b/app/Services/Company/Adminland/Company/CreateCompany.php
@@ -45,6 +45,7 @@ class CreateCompany extends BaseService
         $this->createUniqueInvitationCodeForCompany();
         $this->addFirstEmployee();
         $this->provisionDefaultAccountData();
+        $this->generateSlug();
         $this->logAccountAudit();
 
         return $this->company;
@@ -102,6 +103,13 @@ class CreateCompany extends BaseService
     private function provisionDefaultAccountData(): void
     {
         ProvisionDefaultAccountData::dispatch($this->employee);
+    }
+
+    private function generateSlug(): void
+    {
+        (new UpdateCompanySlug)->execute([
+            'company_id' => $this->company->id,
+        ]);
     }
 
     private function logAccountAudit(): void

--- a/app/Services/Company/Adminland/Company/RenameCompany.php
+++ b/app/Services/Company/Adminland/Company/RenameCompany.php
@@ -50,18 +50,24 @@ class RenameCompany extends BaseService
 
         $this->rename();
 
+        $this->generateSlug();
+
         $this->log($oldName);
 
         return $this->company;
     }
 
-    /**
-     * Rename the company.
-     */
     private function rename(): void
     {
         Company::where('id', $this->company->id)->update([
             'name' => $this->data['name'],
+        ]);
+    }
+
+    private function generateSlug(): void
+    {
+        (new UpdateCompanySlug)->execute([
+            'company_id' => $this->company->id,
         ]);
     }
 

--- a/app/Services/Company/Adminland/Company/UpdateCompanySlug.php
+++ b/app/Services/Company/Adminland/Company/UpdateCompanySlug.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Services\Company\Adminland\Company;
+
+use Illuminate\Support\Str;
+use App\Services\BaseService;
+use App\Models\Company\Company;
+
+class UpdateCompanySlug extends BaseService
+{
+    private Company $company;
+
+    /**
+     * Get the validation rules that apply to the service.
+     *
+     * @return array
+     */
+    public function rules(): array
+    {
+        return [
+            'company_id' => 'required|integer|exists:companies,id',
+        ];
+    }
+
+    /**
+     * Updates the company slug.
+     *
+     * @param array $data
+     *
+     * @return Company
+     */
+    public function execute(array $data): Company
+    {
+        $this->company = Company::find($data['company_id']);
+
+        $slug = Str::slug($this->company->name, '-');
+
+        $isSlugUnique = false;
+        while ($isSlugUnique === false) {
+            $existingCompaniesWithThisSlug = Company::where('slug', '=', $slug)
+                ->where('id', '!=', $this->company->id)
+                ->count();
+
+            if ($existingCompaniesWithThisSlug > 0) {
+                $slug = $slug.'-'.rand(1, 999);
+            }
+
+            $isSlugUnique = Company::where('slug', $slug)
+                ->where('id', '!=', $this->company->id)
+                ->count() == 0;
+        }
+
+        $this->company->slug = $slug;
+        $this->company->save();
+
+        return $this->company->refresh();
+    }
+}

--- a/database/factories/Company/CompanyFactory.php
+++ b/database/factories/Company/CompanyFactory.php
@@ -23,6 +23,7 @@ class CompanyFactory extends Factory
     {
         return [
             'name' => $this->faker->name,
+            'slug' => 'company-name',
             'currency' => 'USD',
             'code_to_join_company' => 'USD',
         ];

--- a/database/migrations/2021_08_02_184706_add_company_slug_to_companies.php
+++ b/database/migrations/2021_08_02_184706_add_company_slug_to_companies.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Support\Str;
+use App\Models\Company\Company;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddCompanySlugToCompanies extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up()
+    {
+        // necessary for SQLlite
+        Schema::enableForeignKeyConstraints();
+
+        Schema::table('companies', function (Blueprint $table) {
+            $table->string('slug')->after('name')->nullable();
+        });
+
+        Company::chunk(200, function ($companies) {
+            foreach ($companies as $company) {
+                $company->slug = Str::slug($company->name, '-');
+                $company->save();
+            }
+        });
+    }
+}

--- a/tests/Unit/Services/Company/Adminland/Company/CreateCompanyTest.php
+++ b/tests/Unit/Services/Company/Adminland/Company/CreateCompanyTest.php
@@ -31,6 +31,8 @@ class CreateCompanyTest extends TestCase
 
         $company = (new CreateCompany)->execute($request);
 
+        $company->refresh();
+
         $michael = $dwight->getEmployeeObjectForCompany($company);
 
         $this->assertInstanceOf(
@@ -44,6 +46,11 @@ class CreateCompanyTest extends TestCase
         ]);
 
         $this->assertNotNull($company->code_to_join_company);
+
+        $this->assertEquals(
+            'dunder-mifflin',
+            $company->slug
+        );
 
         Queue::assertPushed(LogAccountAudit::class, function ($job) use ($michael) {
             return $job->auditLog['action'] === 'account_created' &&

--- a/tests/Unit/Services/Company/Adminland/Company/RenameCompanyTest.php
+++ b/tests/Unit/Services/Company/Adminland/Company/RenameCompanyTest.php
@@ -61,14 +61,14 @@ class RenameCompanyTest extends TestCase
         $request = [
             'company_id' => $michael->company_id,
             'author_id' => $michael->id,
-            'name' => 'Pyramid',
+            'name' => 'Dunder Mifflin 2',
         ];
 
         $company = (new RenameCompany)->execute($request);
 
         $this->assertDatabaseHas('companies', [
             'id' => $company->id,
-            'name' => 'Pyramid',
+            'name' => 'Dunder Mifflin 2',
         ]);
 
         $this->assertInstanceOf(
@@ -76,12 +76,17 @@ class RenameCompanyTest extends TestCase
             $company
         );
 
+        $this->assertEquals(
+            'dunder-mifflin-2',
+            $company->refresh()->slug
+        );
+
         Queue::assertPushed(LogAccountAudit::class, function ($job) use ($michael, $oldName) {
             return $job->auditLog['action'] === 'company_renamed' &&
                 $job->auditLog['author_id'] === $michael->id &&
                 $job->auditLog['objects'] === json_encode([
                     'old_name' => $oldName,
-                    'new_name' => 'Pyramid',
+                    'new_name' => 'Dunder Mifflin 2',
                 ]);
         });
     }

--- a/tests/Unit/Services/Company/Adminland/Company/UpdateCompanySlugTest.php
+++ b/tests/Unit/Services/Company/Adminland/Company/UpdateCompanySlugTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Unit\Services\Company\Adminland\Company;
+
+use Tests\TestCase;
+use App\Models\Company\Company;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use App\Services\Company\Adminland\Company\UpdateCompanySlug;
+
+class UpdateCompanySlugTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    /** @test */
+    public function it_updates_a_slug(): void
+    {
+        $company = Company::factory()->create([
+            'name' => 'Dunder Mifflin',
+        ]);
+
+        $request = [
+            'company_id' => $company->id,
+        ];
+
+        $company = (new UpdateCompanySlug)->execute($request);
+
+        $this->assertInstanceOf(
+            Company::class,
+            $company
+        );
+
+        $this->assertDatabaseHas('companies', [
+            'id' => $company->id,
+            'slug' => 'dunder-mifflin',
+        ]);
+    }
+
+    /** @test */
+    public function it_updates_a_slug_that_is_unique(): void
+    {
+        $company = Company::factory()->create([
+            'name' => 'Dunder Mifflin',
+        ]);
+        Company::factory()->create([
+            'slug' => 'dunder-mifflin',
+        ]);
+
+        $request = [
+            'company_id' => $company->id,
+        ];
+
+        $company = (new UpdateCompanySlug)->execute($request);
+
+        $this->assertInstanceOf(
+            Company::class,
+            $company
+        );
+
+        $this->assertEquals(
+            'dunder-mifflin-',
+            substr($company->slug, 0, 15)
+        );
+    }
+}

--- a/tests/Unit/ViewHelpers/Adminland/AdminGeneralViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Adminland/AdminGeneralViewHelperTest.php
@@ -50,6 +50,11 @@ class AdminGeneralViewHelperTest extends TestCase
         );
 
         $this->assertEquals(
+            $michael->company->slug,
+            $response['slug']
+        );
+
+        $this->assertEquals(
             'Jan 01, 2018 12:00 AM',
             $response['creation_date']
         );


### PR DESCRIPTION
This PR adds a slug to a company object.

Basically, if a company is called `Basecamp`, the slug of the company will be `basecamp`.

If there is already a company with this slug, the slug will be `basecamp-2` instead.

This will be used in #1175, when we will display the open job openings for everyone on the Internet to see.