### PR TITLE
ci: fix failing test

### DIFF
--- a/app/Http/ViewHelpers/Company/CompanyViewHelper.php
+++ b/app/Http/ViewHelpers/Company/CompanyViewHelper.php
@@ -253,7 +253,7 @@ class CompanyViewHelper
 
         $skills = $company->skills()
             ->select('id', 'name')
-            ->latest()
+            ->latest('id')
             ->take(5)
             ->get();
 

--- a/tests/Unit/ViewHelpers/Company/CompanyViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Company/CompanyViewHelperTest.php
@@ -294,12 +294,12 @@ class CompanyViewHelperTest extends TestCase
         $this->assertEquals(
             [
                 0 => [
-                    'name' => $skillA->name,
-                    'url' => env('APP_URL').'/'.$michael->company_id.'/company/skills/'.$skillA->id,
-                ],
-                1 => [
                     'name' => $skillB->name,
                     'url' => env('APP_URL').'/'.$michael->company_id.'/company/skills/'.$skillB->id,
+                ],
+                1 => [
+                    'name' => $skillA->name,
+                    'url' => env('APP_URL').'/'.$michael->company_id.'/company/skills/'.$skillA->id,
                 ],
             ],
             $array['skills']->toArray()


### PR DESCRIPTION
This is because sometimes, CI is so fast that the `latest()` eloquent method, which is based on the timestamps, does not give the intended results.

To be more precise, timestamps in Laravel are limited to seconds, and CI can go so fast that two objects are created in the same second, so the `latest` method does not return the items in the right order.