### PR TITLE
fix: show only members who were present in the meeting

### DIFF
--- a/app/Http/ViewHelpers/Company/Group/GroupMeetingsViewHelper.php
+++ b/app/Http/ViewHelpers/Company/Group/GroupMeetingsViewHelper.php
@@ -25,11 +25,12 @@ class GroupMeetingsViewHelper
         $meetingsCollection = collect([]);
         foreach ($meetings as $meeting) {
             $members = $meeting->employees()
+                ->wherePivot('attended', true)
                 ->inRandomOrder()
                 ->take(3)
                 ->get();
 
-            $totalMembersCount = $meeting->employees()->count();
+            $totalMembersCount = $meeting->employees()->wherePivot('attended', true)->count();
             $totalMembersCount = $totalMembersCount - $members->count();
 
             $membersCollection = collect([]);

--- a/app/Http/ViewHelpers/Company/Group/GroupShowViewHelper.php
+++ b/app/Http/ViewHelpers/Company/Group/GroupShowViewHelper.php
@@ -77,11 +77,12 @@ class GroupShowViewHelper
         $meetingsCollection = collect([]);
         foreach ($meetings as $meeting) {
             $members = $meeting->employees()
+                ->wherePivot('attended', true)
                 ->inRandomOrder()
                 ->take(3)
                 ->get();
 
-            $totalMembersCount = $meeting->employees()->count();
+            $totalMembersCount = $meeting->employees()->wherePivot('attended', true)->count();
             $totalMembersCount = $totalMembersCount - $members->count();
 
             $membersCollection = collect([]);

--- a/resources/js/Pages/Company/Group/Meetings/Partials/Agenda.vue
+++ b/resources/js/Pages/Company/Group/Meetings/Partials/Agenda.vue
@@ -61,7 +61,7 @@
               <small-name-and-avatar
                 :name="agendaItem.presenter.name"
                 :avatar="agendaItem.presenter.avatar"
-                :class="'gray'"
+                :class="'gray bb-0'"
                 :size="'18px'"
                 :top="'0px'"
                 :margin-between-name-avatar="'25px'"

--- a/tests/Unit/ViewHelpers/Company/Group/GroupMeetingsViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Company/Group/GroupMeetingsViewHelperTest.php
@@ -28,7 +28,7 @@ class GroupMeetingsViewHelperTest extends TestCase
             'group_id' => $group->id,
             'happened_at' => Carbon::now(),
         ]);
-        $meeting->employees()->attach([$michael->id]);
+        $meeting->employees()->attach([$michael->id => ['attended' => true]]);
 
         $array = GroupMeetingsViewHelper::index($group);
 

--- a/tests/Unit/ViewHelpers/Company/Group/GroupShowViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Company/Group/GroupShowViewHelperTest.php
@@ -77,7 +77,7 @@ class GroupShowViewHelperTest extends TestCase
             'group_id' => $group->id,
             'happened_at' => Carbon::now(),
         ]);
-        $meeting->employees()->attach([$michael->id]);
+        $meeting->employees()->attach([$michael->id => ['attended' => true]]);
 
         $collection = GroupShowViewHelper::meetings($group);
 


### PR DESCRIPTION
Thanks for contributing.

Please make sure your PR follows those guidelines:

## Availability and Testing

- [ ] Unit tests for everything.
- [ ] Documentation has been written on the [documentation website](https://github.com/officelifehq/docs).
- [ ] Dummy data in the `SetupDummyAccount` file, so test accounts are populated automatically with fresh data.

## `.env` file

- [ ] If you change or add a variable in the `.env` file, don't forget to update the `.env.example` file.
